### PR TITLE
Hooks v2 implementation

### DIFF
--- a/lib/BackgroundJob/Tasks/CreateClustersTask.php
+++ b/lib/BackgroundJob/Tasks/CreateClustersTask.php
@@ -133,7 +133,7 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 					'For cluster creation, you need either one of the following:');
 				$this->logInfo(sprintf('* have 1000 faces already processed (you have %d),', $facesCount));
 				$this->logInfo(sprintf('* have 100 images (you have %d),', $imageCount));
-				$this->logInfo(sprintf('* or you need to have 95%% of you images processed (you have %f)', $percentImagesProcessed));
+				$this->logInfo(sprintf('* or you need to have 95%% of you images processed (you have %.2f%%)', $percentImagesProcessed));
 				return;
 			}
 		}

--- a/lib/Db/FaceNewMapper.php
+++ b/lib/Db/FaceNewMapper.php
@@ -8,7 +8,7 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 
 class FaceNewMapper extends Mapper {
 	public function __construct(IDBConnection $db) {
-		parent::__construct($db, 'face_recognition', '\OCA\FaceRecognition\Db\FaceNew');
+		parent::__construct($db, 'face_recognition_faces', '\OCA\FaceRecognition\Db\FaceNew');
 	}
 
 	public function countFaces(string $userId, $model): int {
@@ -40,6 +40,16 @@ class FaceNewMapper extends Mapper {
 			->setParameter('model', $model);
 		$faces = $this->frFindEntities($qb);
 		return $faces;
+	}
+
+	/**
+	 * @param int $imageId Image for which to delete faces for
+	 */
+	public function removeFaces(int $imageId) {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('image', $qb->createNamedParameter($imageId)))
+			->execute();
 	}
 
 	/**


### PR DESCRIPTION
This change implements add/modify/delete file hooks, as per functional spec (or similar to it:) I am not touching existing hooks.

When file is added, it is just added to `Image` DB table. If file is changed, it is reset in `Image` table, and all persons that had faces from that image are set is `is_valid=false` (so, that we signal person is not up-to-date). When file is deleted, we do the same, but remove it from `Image` table.

Also experimenting how we get `$owner`. Instead of:
```
$absPath = ltrim($file->getPath(), '/');
$owner = explode('/', $absPath)[0];
```
I am trying with:
```
$owner = $node->getOwner()->getUid();
```

Maybe it's the same, not sure.

Also blocked any callback for modifications for other storages (shared, external...) as they don't have reliable callbacks (but have to dig more on this).

Some small bug fixes in this, too