### PR TITLE
Mimetype change is not problem, closes #28

### DIFF
--- a/lib/Watcher.php
+++ b/lib/Watcher.php
@@ -142,7 +142,6 @@ class Watcher {
 			return;
 		}
 
-		// todo: what if file was image and now its mimetype is changed?:) we should remove it
 		// todo: honor .nomedia here
 		if (!Requirements::isImageTypeSupported($node->getMimeType())) {
 			return;
@@ -213,7 +212,6 @@ class Watcher {
 			return;
 		}
 
-		// todo: what if file was image and now its mimetype is changed?:) we should remove it
 		if (!Requirements::isImageTypeSupported($node->getMimeType())) {
 			return;
 		}


### PR DESCRIPTION
So, it turns out, I was wrong in my assumptions. Mimetype is not
determined in some automagical fashion, but simply as extension from
filename. So, that means - there was no problem and I just removed TODO
items in this commit:)

Simple test to deduce is:
* Create TXT file with some text in it and rename it as foo.jpg
* Upload to nextcloud
* Detect from DB (oc_mimetypes) that mimetype is image/jpeg (this means
* NC is not smart to peek into content and deduce mimetype)