### PR TITLE
Handle (partially) .nomedia cases, fixes #29

### DIFF
--- a/lib/BackgroundJob/Tasks/AddMissingImagesTask.php
+++ b/lib/BackgroundJob/Tasks/AddMissingImagesTask.php
@@ -89,7 +89,6 @@ class AddMissingImagesTask extends FaceRecognitionBackgroundTask {
 			});
 		} else {
 			$eligable_users[] = $this->context->user->getUID();
-
 		}
 
 		foreach($eligable_users as $user) {


### PR DESCRIPTION
Fixes cases when image is modified inside some directory which has
`.nomedia` in it, or some of its ancestor dirs have .nomedia.

Also fixes case when `.nomedia` file (itself!) is deleted, as this means all
images from this directory (and child directories) are now eligable for face
detection. However, similar case (when `.nomedia` file is added to some
directory) is not handled and is just referenced as issue #37. This one
requires new task to be added.