### PR TITLE
Central place for loading DNN models, fixes #15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ opt
 js/handlebars.js
 js/lozad.js
 vendor/
+models/1

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,26 @@ source_dir=$(build_dir)/source
 package_name=$(app_name)
 cert_dir=$(HOME)/.nextcloud/certificates
 
-deps:
+default: deps
+
+models/1/mmod_human_face_detector.dat:
+	mkdir -p models/1
+	wget https://github.com/davisking/dlib-models/raw/94cdb1e40b1c29c0bfcaf7355614bfe6da19460e/mmod_human_face_detector.dat.bz2 -O models/1/mmod_human_face_detector.dat.bz2
+	bzip2 -d models/1/mmod_human_face_detector.dat.bz2
+
+models/1/dlib_face_recognition_resnet_model_v1.dat:
+	mkdir -p models/1
+	wget https://github.com/davisking/dlib-models/raw/2a61575dd45d818271c085ff8cd747613a48f20d/dlib_face_recognition_resnet_model_v1.dat.bz2 -O models/1/dlib_face_recognition_resnet_model_v1.dat.bz2
+	bzip2 -d models/1/dlib_face_recognition_resnet_model_v1.dat.bz2
+
+models/1/shape_predictor_5_face_landmarks.dat:
+	mkdir -p models/1
+	wget https://github.com/davisking/dlib-models/raw/4af9b776281dd7d6e2e30d4a2d40458b1e254e40/shape_predictor_5_face_landmarks.dat.bz2 -O models/1/shape_predictor_5_face_landmarks.dat.bz2
+	bzip2 -d models/1/shape_predictor_5_face_landmarks.dat.bz2
+
+download_models: models/1/mmod_human_face_detector.dat models/1/dlib_face_recognition_resnet_model_v1.dat models/1/shape_predictor_5_face_landmarks.dat
+
+deps: download_models
 	rm -f js/handlebars.js js/lozad.js
 	wget http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v4.0.5.js -O js/handlebars.js
 	wget https://raw.githubusercontent.com/ApoorvSaxena/lozad.js/master/dist/lozad.js -O js/lozad.js
@@ -39,3 +58,8 @@ appstore:
 	tar -czf $(build_dir)/$(app_name).tar.gz \
 		-C $(sign_dir) $(app_name)
 	openssl dgst -sha512 -sign $(cert_dir)/$(app_name).key $(build_dir)/$(app_name).tar.gz | openssl base64
+
+clean:
+	rm -f models/1/mmod_human_face_detector.dat
+	rm -f models/1/dlib_face_recognition_resnet_model_v1.dat
+	rm -f models/1/shape_predictor_5_face_landmarks.dat

--- a/lib/BackgroundJob/BackgroundService.php
+++ b/lib/BackgroundJob/BackgroundService.php
@@ -26,8 +26,8 @@ namespace OCA\FaceRecognition\BackgroundJob;
 use OCA\FaceRecognition\AppInfo\Application;
 use OCA\FaceRecognition\Helper\Requirements;
 
-use OCA\FaceRecognition\BackgroundJob\Tasks\CheckPdlibTask;
 use OCA\FaceRecognition\BackgroundJob\Tasks\CheckCronTask;
+use OCA\FaceRecognition\BackgroundJob\Tasks\CheckRequirementsTask;
 use OCA\FaceRecognition\BackgroundJob\Tasks\LockTask;
 use OCA\FaceRecognition\BackgroundJob\Tasks\CreateClustersTask;
 use OCA\FaceRecognition\BackgroundJob\Tasks\AddMissingImagesTask;
@@ -60,8 +60,8 @@ class BackgroundService {
 	}
 
 	public function setLogger($logger) {
-		// todo: relax this check, so that logger could be set, anytime, but before execute is called
 		if (!is_null($this->context->logger)) {
+			// If you get this exception, it means you already initialized context->logger. Double-check your flow.
 			throw new \LogicException('You cannot call setLogger after you set it once');
 		}
 
@@ -85,14 +85,13 @@ class BackgroundService {
 		// Here we are defining all the tasks that will get executed.
 		//
 		$task_classes = [
-			CheckPdlibTask::class,
+			CheckRequirementsTask::class,
 			CheckCronTask::class,
 			LockTask::class,
 			CreateClustersTask::class,
 			AddMissingImagesTask::class,
 			EnumerateImagesMissingFacesTask::class,
 			ImageProcessingTask::class,
-			// ...
 			UnlockTask::class
 		];
 

--- a/lib/BackgroundJob/FaceRecognitionLogger.php
+++ b/lib/BackgroundJob/FaceRecognitionLogger.php
@@ -65,7 +65,6 @@ class FaceRecognitionLogger {
 			$this->output->writeln($message);
 		} else {
 			throw new \RuntimeException("There are no configured loggers. Please file an issue at https://github.com/matiasdelellis/facerecognition/issues");
-			// todo: handle somehow this black hole output
 		}
 	}
 

--- a/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
+++ b/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
@@ -23,19 +23,33 @@
  */
 namespace OCA\FaceRecognition\BackgroundJob\Tasks;
 
+use OCP\IConfig;
+
 use OCA\FaceRecognition\BackgroundJob\FaceRecognitionBackgroundTask;
 use OCA\FaceRecognition\BackgroundJob\FaceRecognitionContext;
 use OCA\FaceRecognition\Helper\Requirements;
+use OCA\FaceRecognition\Migration\AddDefaultFaceModel;
 
 /**
  * Check all requirements before we start engaging in lengthy background task.
  */
-class CheckPdlibTask extends FaceRecognitionBackgroundTask {
+class CheckRequirementsTask extends FaceRecognitionBackgroundTask {
+	/** @var IConfig Config */
+	private $config;
+
+	/**
+	 * @param IConfig $config Config
+	 */
+	public function __construct(IConfig $config) {
+		parent::__construct();
+		$this->config = $config;
+	}
+
 	/**
 	 * @inheritdoc
 	 */
 	public function description() {
-		return "Check Pdlib installed";
+		return "Check all requirements";
 	}
 
 	/**
@@ -43,10 +57,20 @@ class CheckPdlibTask extends FaceRecognitionBackgroundTask {
 	 */
 	public function do(FaceRecognitionContext $context) {
 		$this->setContext($context);
-		// todo: good chunk of Requirements class is good candidate to be part of this checks
-		$req = new Requirements($context->appManager);
+		$model = intval($this->config->getAppValue('facerecognition', 'model', AddDefaultFaceModel::DEFAULT_FACE_MODEL_ID));
+
+		$req = new Requirements($context->appManager, $model);
+
 		if (!$req->pdlibLoaded()) {
 			$this->logInfo('PDLib is not loaded. Cannot continue');
+			// todo: convert to exception
+			return;
+		}
+
+		if (!$req->modelFilesPresent()) {
+			$this->logInfo('Files of model with ID ' . $model . ' are not present in models/ directory.');
+			$this->logInfo('Please contact administrator to change models you are using for face recognition');
+			$this->logInfo('or reinstall application. File an issue here if that doesn\'t help: https://github.com/matiasdelellis/facerecognition/issues');
 			// todo: convert to exception
 			return;
 		}

--- a/lib/Command/Analyze.php
+++ b/lib/Command/Analyze.php
@@ -136,7 +136,7 @@ class Analyze extends Command {
 			return 1;
 		}
 
-		$req = new Requirements($this->appManager);
+		$req = new Requirements($this->appManager, -1);
 
 		if (!$req->pdlibLoaded())
 			$this->output->writeln('pdlib extension is not loaded. Try to use python helper.');

--- a/lib/Command/Check.php
+++ b/lib/Command/Check.php
@@ -80,7 +80,7 @@ class Check extends Command {
 
 		$checkStatus = TRUE;
 
-		$req = new Requirements($this->appManager);
+		$req = new Requirements($this->appManager, -1);
 
 		if ($req->pdlibLoaded()) {
 			$this->output->writeln('');

--- a/lib/Helper/Requirements.php
+++ b/lib/Helper/Requirements.php
@@ -9,15 +9,36 @@ class Requirements
 	/** @var \OCP\App\IAppManager **/
 	protected $appManager;
 
-	function __construct(IAppManager $appManager) {
+	/** @var int ID of used model */
+	private $model;
+
+	function __construct(IAppManager $appManager, int $model) {
 		$this->appManager = $appManager;
+		$this->model = $model;
 	}
 
-	public function pdlibLoaded ()
-	{
-		return extension_loaded ('pdlib');
+	public function pdlibLoaded() {
+		return extension_loaded('pdlib');
 	}
 
+	public function modelFilesPresent(): bool {
+		// todo: convert to exceptions
+		if ($this->model === 1) {
+			$faceDetection = $this->getFaceDetectionModelv2();
+			$landmarkDetection = $this->getLandmarksDetectionModelv2();
+			$faceRecognition = $this->getFaceRecognitionModelv2();
+
+			if (($faceDetection === NULL) || ($landmarkDetection === NULL) || ($faceRecognition === NULL)) {
+				return false;
+			} else {
+				return true;
+			}
+		} else {
+			// Since current app version only can handle model with ID=1,
+			// we surely cannot check if files from other model exist
+			return false;
+		}
+	}
 	public function getPythonHelper ()
 	{
 		if (file_exists('/bin/nextcloud-face-recognition-cmd') ||
@@ -42,6 +63,18 @@ class Requirements
 		}
 	}
 
+	public function getFaceRecognitionModelv2() {
+		if ($this->model !== 1) {
+			return NULL;
+		}
+
+		if (file_exists($this->appManager->getAppPath('facerecognition').'/models/1/dlib_face_recognition_resnet_model_v1.dat')) {
+			return $this->appManager->getAppPath('facerecognition').'/models/1/dlib_face_recognition_resnet_model_v1.dat';
+		} else {
+			return NULL;
+		}
+	}
+
 	public function getLandmarksModel ()
 	{
 		if (file_exists($this->appManager->getAppPath('facerecognition').'/vendor/models/shape_predictor_5_face_landmarks.dat')) {
@@ -51,6 +84,30 @@ class Requirements
 			return $this->appManager->getAppPath('facerecognition').'/vendor/models/shape_predictor_68_face_landmarks.dat';
 		}
 		else {
+			return NULL;
+		}
+	}
+
+	public function getLandmarksDetectionModelv2() {
+		if ($this->model !== 1) {
+			return NULL;
+		}
+
+		if (file_exists($this->appManager->getAppPath('facerecognition').'/models/1/shape_predictor_5_face_landmarks.dat')) {
+			return $this->appManager->getAppPath('facerecognition').'/models/1/shape_predictor_5_face_landmarks.dat';
+		} else {
+			return NULL;
+		}
+	}
+
+	public function getFaceDetectionModelv2() {
+		if ($this->model !== 1) {
+			return NULL;
+		}
+
+		if (file_exists($this->appManager->getAppPath('facerecognition').'/models/1/mmod_human_face_detector.dat')) {
+			return $this->appManager->getAppPath('facerecognition').'/models/1/mmod_human_face_detector.dat';
+		} else {
 			return NULL;
 		}
 	}

--- a/models/LICENCE.md
+++ b/models/LICENCE.md
@@ -1,0 +1,7 @@
+This licence file covers models' licences in these directories.
+
+# Model 1 (directory `1/`)
+
+* The models used for facecerecognition are extracted from [dlib models](https://github.com/davisking/dlib-models) repository
+* General license of models can be found in [dlib LICENCE](https://github.com/davisking/dlib-models/blob/15f41a5d4e1d152b809227a3c912cd9c400e1b8a/LICENSE)
+* More details can be found at [dlib README]( https://github.com/davisking/dlib-models/blob/ae50fe33583de33c60276611d37915e93d11566b/README.md)

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,8 @@
+This directory holds all model files which are required by facerecognition app to work properly.
+
+Each set of files from a model is in separate directory, where directory name is identified of the model.
+
+You should at least have one directory named '1/' in here. If this directory is not present, or it is empty
+(there are no models in it), try executing `make download_models` from root directory of the application.
+
+If this doesn't help, file an issue at: https://github.com/matiasdelellis/facerecognition/issues


### PR DESCRIPTION
This change adds support to download models in Makefile (and adds it as
default target in make).

Requirement task is renamed to check not only does pdlib is loaded, but
also if model files are present.

Requirement class is changed, so modelId is required argument for it to
operate. It encapsulate logic to retrieve paths to model files based on
model ID (which currently does not make any sense:) as we have only one
model), but yes - Requirement now hides this from developer.