### PR TITLE
Adding support for travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ js/handlebars.js
 js/lozad.js
 vendor/
 models/1
+clover.xml

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,6 @@
+imports:
+    - php
+
+tools:
+    external_code_coverage: true
+      timeout: 1000

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+sudo: false
+
+language: php
+
+services:
+  - mysql
+  - postgresql
+
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+  - nightly
+
+env:
+  global:
+    - CORE_BRANCH=stable14
+    - APP_NAME=facerecognition
+  matrix:
+    - DB=mysql
+    - DB=pgsql
+    - DB=sqlite
+
+before_install:
+  - make
+  - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh;
+  - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
+  - cd ../server;
+  - ./occ app:enable $APP_NAME
+
+before_script:
+  # until #42 is fixed - ./occ app:check-code $APP_NAME
+  - cd apps/$APP_NAME
+
+script:
+  - make test
+
+  # Create coverage report
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover clover.xml
+
+after_failure:
+  - cat ../../data/nextcloud.log
+

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ appstore:
 		-C $(sign_dir) $(app_name)
 	openssl dgst -sha512 -sign $(cert_dir)/$(app_name).key $(build_dir)/$(app_name).tar.gz | openssl base64
 
+test: deps
+	phpunit --coverage-clover clover.xml -c phpunit.xml
+
 clean:
 	rm -f models/1/mmod_human_face_detector.dat
 	rm -f models/1/dlib_face_recognition_resnet_model_v1.dat

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -80,6 +80,7 @@ class Application extends App {
 	 * Register admin settings
 	 */
 	public function registerAdminPage() {
+		// TODO: this should be removed and rewriten, as per issue #42
 		\OCP\App::registerAdmin($this->getContainer()->getAppName(), 'templates/settings');
 	}
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,4 +4,9 @@
             <directory>./tests/unit</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">lib</directory>
+        </whitelist>
+</filter>
 </phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,7 @@
 
 \OC_App::loadApp('facerecognition');
 
-if(!class_exists('PHPUnit_Framework_TestCase')) {
+if(!class_exists('PHPUnit_Framework_TestCase') && !class_exists('\PHPUnit\Framework\TestCase')) {
 	require_once('PHPUnit/Autoload.php');
 }
 


### PR DESCRIPTION
I am trying to add support for Travis CI and for code coverage. I think I got something working, however I would like to continue on master. @matiasdelellis you should add `matiasdelellis/facerecognition` repo to Travis, please!

I think I have something working, as [you can see](https://travis-ci.com/stalker314314/facerecognition/builds/90990357), but I will not yet close #41 as I somehow still don't see [code coverage](https://scrutinizer-ci.com/g/stalker314314/facerecognition/). BTW, we are not passing `./occ app:check` anymore (since NC14), as `registerAdmin` got deprecated in NC14. I opened #42 for this.

I plan to continue working on this integration pipeline, there will be more tweaks/fixes/improvements... For you @matiasdelellis - please onboard this repo to Travis and Scrutinizer when you find time!