### PR TITLE
Fix cluster recreation

### DIFF
--- a/lib/BackgroundJob/Tasks/CreateClustersTask.php
+++ b/lib/BackgroundJob/Tasks/CreateClustersTask.php
@@ -150,7 +150,7 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 		$this->logInfo(count($newClusters) . ' clusters found for clustering');
 		// New merge
 		$mergedClusters = $this->mergeClusters($currentClusters, $newClusters);
-		$this->personMapper->mergeClusterToDatabase($userId, $currentClusters, $newClusters);
+		$this->personMapper->mergeClusterToDatabase($userId, $currentClusters, $mergedClusters);
 	}
 
 	private function getCurrentClusters(array $faces): array {


### PR DESCRIPTION
https://scrutinizer-ci.com/g/matiasdelellis/facerecognition/issues/master/files/lib/BackgroundJob/Tasks/CreateClustersTask.php?orderField=path&order=asc&honorSelectedPaths=0&issueId=33561413

As seen above, it was obvious I forgot to use correct variable:) Everything did work, but new clusters were getting recreated every time and old ones are getting invaluidated by setting is_valid to false