### PR TITLE
Add exceptions to background tasks

### DIFF
--- a/lib/BackgroundJob/FaceRecognitionBackgroundTask.php
+++ b/lib/BackgroundJob/FaceRecognitionBackgroundTask.php
@@ -40,8 +40,10 @@ interface IFaceRecognitionBackgroundTask {
 	 * Executes task.
 	 *
 	 * @param FaceRecognitionContext $context Face recognition context
+	 * @return \Generator|bool Since we are yielding, return type is either Generator, or boolean (actual return).
+	 * Return value specifies should we continue execution. True if we should continue, false if we should bail out.
 	 */
-	public function do(FaceRecognitionContext $context);
+	public function execute(FaceRecognitionContext $context);
 }
 
 /**

--- a/lib/BackgroundJob/FaceRecognitionBackgroundTask.php
+++ b/lib/BackgroundJob/FaceRecognitionBackgroundTask.php
@@ -58,7 +58,7 @@ abstract class FaceRecognitionBackgroundTask implements IFaceRecognitionBackgrou
 	}
 
 	/**
-	 * Sets context for a given task, so it can accessed in task (without a need to dragging it around from do() method).
+	 * Sets context for a given task, so it can accessed in task (without a need to dragging it around from execute() method).
 	 *
 	 * @param FaceRecognitionContext $context Context
 	 */

--- a/lib/BackgroundJob/FaceRecognitionBackgroundTask.php
+++ b/lib/BackgroundJob/FaceRecognitionBackgroundTask.php
@@ -40,7 +40,7 @@ interface IFaceRecognitionBackgroundTask {
 	 * Executes task.
 	 *
 	 * @param FaceRecognitionContext $context Face recognition context
-	 * @return boolean|\Generator Since we are yielding, return type is either Generator, or boolean (actual return).
+	 * @return \Generator|bool Since we are yielding, return type is either Generator, or boolean (actual return).
 	 * Return value specifies should we continue execution. True if we should continue, false if we should bail out.
 	 */
 	public function execute(FaceRecognitionContext $context);

--- a/lib/BackgroundJob/FaceRecognitionBackgroundTask.php
+++ b/lib/BackgroundJob/FaceRecognitionBackgroundTask.php
@@ -40,7 +40,7 @@ interface IFaceRecognitionBackgroundTask {
 	 * Executes task.
 	 *
 	 * @param FaceRecognitionContext $context Face recognition context
-	 * @return bool|\Generator Since we are yielding, return type is either Generator, or boolean (actual return).
+	 * @return boolean|\Generator Since we are yielding, return type is either Generator, or boolean (actual return).
 	 * Return value specifies should we continue execution. True if we should continue, false if we should bail out.
 	 */
 	public function execute(FaceRecognitionContext $context);

--- a/lib/BackgroundJob/FaceRecognitionBackgroundTask.php
+++ b/lib/BackgroundJob/FaceRecognitionBackgroundTask.php
@@ -40,7 +40,7 @@ interface IFaceRecognitionBackgroundTask {
 	 * Executes task.
 	 *
 	 * @param FaceRecognitionContext $context Face recognition context
-	 * @return \Generator|bool Since we are yielding, return type is either Generator, or boolean (actual return).
+	 * @return bool|\Generator Since we are yielding, return type is either Generator, or boolean (actual return).
 	 * Return value specifies should we continue execution. True if we should continue, false if we should bail out.
 	 */
 	public function execute(FaceRecognitionContext $context);

--- a/lib/BackgroundJob/Tasks/AddMissingImagesTask.php
+++ b/lib/BackgroundJob/Tasks/AddMissingImagesTask.php
@@ -70,13 +70,13 @@ class AddMissingImagesTask extends FaceRecognitionBackgroundTask {
 	/**
 	 * @inheritdoc
 	 */
-	public function do(FaceRecognitionContext $context) {
+	public function execute(FaceRecognitionContext $context) {
 		$this->setContext($context);
 
 		$fullImageScanDone = $this->config->getAppValue('facerecognition', AddMissingImagesTask::FULL_IMAGE_SCAN_DONE_KEY, 'false');
 		if ($fullImageScanDone == 'true') {
 			// Completely skip this task, seems that we already did full scan
-			return;
+			return true;
 		}
 
 		$model = intval($this->config->getAppValue('facerecognition', 'model', AddDefaultFaceModel::DEFAULT_FACE_MODEL_ID));
@@ -99,6 +99,8 @@ class AddMissingImagesTask extends FaceRecognitionBackgroundTask {
 		if (is_null($this->context->user)) {
 			$this->config->setAppValue('facerecognition', AddMissingImagesTask::FULL_IMAGE_SCAN_DONE_KEY, 'true');
 		}
+
+		return true;
 	}
 
 	/**

--- a/lib/BackgroundJob/Tasks/CheckCronTask.php
+++ b/lib/BackgroundJob/Tasks/CheckCronTask.php
@@ -40,7 +40,7 @@ class CheckCronTask extends FaceRecognitionBackgroundTask {
 	/**
 	 * @inheritdoc
 	 */
-	public function do(FaceRecognitionContext $context) {
+	public function execute(FaceRecognitionContext $context) {
 		$this->setContext($context);
 
 		$isCommand = $context->isRunningThroughCommand();
@@ -51,7 +51,9 @@ class CheckCronTask extends FaceRecognitionBackgroundTask {
 				"For details, take a look at " .
 				"https://docs.nextcloud.com/server/14/admin_manual/configuration_server/background_jobs_configuration.html";
 			$this->logInfo($message);
-			throw new \RuntimeException($message);
+			return false;
 		}
+
+		return true;
 	}
 }

--- a/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
+++ b/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
@@ -62,17 +62,18 @@ class CheckRequirementsTask extends FaceRecognitionBackgroundTask {
 		$req = new Requirements($context->appManager, $model);
 
 		if (!$req->pdlibLoaded()) {
-			$this->logInfo('PDLib is not loaded. Cannot continue');
-			// todo: convert to exception
-			return;
+			$error_message = "PDLib is not loaded. Cannot continue";
+			$this->logInfo($error_message);
+			throw new \RuntimeException($error_message);
 		}
 
 		if (!$req->modelFilesPresent()) {
-			$this->logInfo('Files of model with ID ' . $model . ' are not present in models/ directory.');
-			$this->logInfo('Please contact administrator to change models you are using for face recognition');
-			$this->logInfo('or reinstall application. File an issue here if that doesn\'t help: https://github.com/matiasdelellis/facerecognition/issues');
-			// todo: convert to exception
-			return;
+			$error_message =
+				"Files of model with ID ' . $model . ' are not present in models/ directory.\n" .
+				"Please contact administrator to change models you are using for face recognition\n" .
+				"or reinstall application. File an issue here if that doesn\'t help: https://github.com/matiasdelellis/facerecognition/issues";
+			$this->logInfo($error_message);
+			throw new \RuntimeException($error_message);
 		}
 	}
 }

--- a/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
+++ b/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
@@ -55,7 +55,7 @@ class CheckRequirementsTask extends FaceRecognitionBackgroundTask {
 	/**
 	 * @inheritdoc
 	 */
-	public function do(FaceRecognitionContext $context) {
+	public function execute(FaceRecognitionContext $context) {
 		$this->setContext($context);
 		$model = intval($this->config->getAppValue('facerecognition', 'model', AddDefaultFaceModel::DEFAULT_FACE_MODEL_ID));
 
@@ -64,7 +64,7 @@ class CheckRequirementsTask extends FaceRecognitionBackgroundTask {
 		if (!$req->pdlibLoaded()) {
 			$error_message = "PDLib is not loaded. Cannot continue";
 			$this->logInfo($error_message);
-			throw new \RuntimeException($error_message);
+			return false;
 		}
 
 		if (!$req->modelFilesPresent()) {
@@ -73,7 +73,9 @@ class CheckRequirementsTask extends FaceRecognitionBackgroundTask {
 				"Please contact administrator to change models you are using for face recognition\n" .
 				"or reinstall application. File an issue here if that doesn\'t help: https://github.com/matiasdelellis/facerecognition/issues";
 			$this->logInfo($error_message);
-			throw new \RuntimeException($error_message);
+			return false;
 		}
+
+		return true;
 	}
 }

--- a/lib/BackgroundJob/Tasks/CreateClustersTask.php
+++ b/lib/BackgroundJob/Tasks/CreateClustersTask.php
@@ -75,7 +75,7 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 	/**
 	 * @inheritdoc
 	 */
-	public function do(FaceRecognitionContext $context) {
+	public function execute(FaceRecognitionContext $context) {
 		$this->setContext($context);
 
 		$fullImageScanDone = $this->config->getAppValue('facerecognition', AddMissingImagesTask::FULL_IMAGE_SCAN_DONE_KEY, 'false');
@@ -83,7 +83,7 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 			// If not all images are not interested in the database, we cannot determine when we should start clustering.
 			// Since this is step in beggining, just bail out.
 			$this->logInfo('Skipping cluster creation, as not even existing images are found and inserted in database');
-			return;
+			return true;
 		}
 
 		// We cannot yield inside of Closure, so we need to extract all users and iterate outside of closure.
@@ -101,6 +101,8 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 		foreach($eligable_users as $user) {
 			$this->createClusterIfNeeded($user);
 		}
+
+		return true;
 	}
 
 	private function createClusterIfNeeded(string $userId) {

--- a/lib/BackgroundJob/Tasks/EnumerateImagesMissingFacesTask.php
+++ b/lib/BackgroundJob/Tasks/EnumerateImagesMissingFacesTask.php
@@ -23,10 +23,7 @@
  */
 namespace OCA\FaceRecognition\BackgroundJob\Tasks;
 
-use OCP\Files\File;
-use OCP\Files\Folder;
 use OCP\IDBConnection;
-use OCP\IUser;
 
 use OCA\FaceRecognition\Db\Image;
 use OCA\FaceRecognition\Db\ImageMapper;

--- a/lib/BackgroundJob/Tasks/EnumerateImagesMissingFacesTask.php
+++ b/lib/BackgroundJob/Tasks/EnumerateImagesMissingFacesTask.php
@@ -64,7 +64,7 @@ class EnumerateImagesMissingFacesTask extends FaceRecognitionBackgroundTask {
 	/**
 	 * @inheritdoc
 	 */
-	public function do(FaceRecognitionContext $context) {
+	public function execute(FaceRecognitionContext $context) {
 		$this->setContext($context);
 
 		$images = $this->imageMapper->findImagesWithoutFaces($this->context->user);
@@ -72,5 +72,7 @@ class EnumerateImagesMissingFacesTask extends FaceRecognitionBackgroundTask {
 
 		shuffle($images);
 		$this->context->propertyBag['images'] = $images;
+
+		return true;
 	}
 }

--- a/lib/BackgroundJob/Tasks/ImageProcessingTask.php
+++ b/lib/BackgroundJob/Tasks/ImageProcessingTask.php
@@ -126,7 +126,7 @@ class ImageProcessingTask extends FaceRecognitionBackgroundTask {
 	/**
 	 * @inheritdoc
 	 */
-	public function do(FaceRecognitionContext $context) {
+	public function execute(FaceRecognitionContext $context) {
 		$this->setContext($context);
 
 		$model = intval($this->config->getAppValue('facerecognition', 'model', AddDefaultFaceModel::DEFAULT_FACE_MODEL_ID));
@@ -162,6 +162,8 @@ class ImageProcessingTask extends FaceRecognitionBackgroundTask {
 				$this->tempManager->clean();
 			}
 		}
+
+		return true;
 	}
 
 	/**

--- a/lib/BackgroundJob/Tasks/LockTask.php
+++ b/lib/BackgroundJob/Tasks/LockTask.php
@@ -43,17 +43,18 @@ class LockTask extends FaceRecognitionBackgroundTask {
 	/**
 	 * @inheritdoc
 	 */
-	public function do(FaceRecognitionContext $context) {
+	public function execute(FaceRecognitionContext $context) {
 		$lock_file = sys_get_temp_dir() . '/' . LOCK_FILENAME;
 		$fp = fopen($lock_file, 'w');
 
 		if (!$fp || !flock($fp, LOCK_EX | LOCK_NB, $eWouldBlock) || $eWouldBlock) {
 			$message = "Background job is already running. Quitting";
 			$this->logInfo($message);
-			throw new \RuntimeException($message);
+			return false;
 		}
 
 		$context->propertyBag['lock'] = $fp;
 		$context->propertyBag['lock_filename'] = $lock_file;
+		return true;
 	}
 }

--- a/lib/BackgroundJob/Tasks/UnlockTask.php
+++ b/lib/BackgroundJob/Tasks/UnlockTask.php
@@ -40,8 +40,9 @@ class UnlockTask extends FaceRecognitionBackgroundTask {
 	/**
 	 * @inheritdoc
 	 */
-	public function do(FaceRecognitionContext $context) {
+	public function execute(FaceRecognitionContext $context) {
 		flock($context->propertyBag['lock'], LOCK_UN);
 		unlink($context->propertyBag['lock_filename']);
+		return true;
 	}
 }

--- a/lib/Helper/Requirements.php
+++ b/lib/Helper/Requirements.php
@@ -12,7 +12,7 @@ class Requirements
 	/** @var int ID of used model */
 	private $model;
 
-	function __construct(IAppManager $appManager, int $model) {
+	public function __construct(IAppManager $appManager, int $model) {
 		$this->appManager = $appManager;
 		$this->model = $model;
 	}
@@ -22,7 +22,6 @@ class Requirements
 	}
 
 	public function modelFilesPresent(): bool {
-		// todo: convert to exceptions
 		if ($this->model === 1) {
 			$faceDetection = $this->getFaceDetectionModelv2();
 			$landmarkDetection = $this->getLandmarksDetectionModelv2();
@@ -64,15 +63,7 @@ class Requirements
 	}
 
 	public function getFaceRecognitionModelv2() {
-		if ($this->model !== 1) {
-			return NULL;
-		}
-
-		if (file_exists($this->appManager->getAppPath('facerecognition').'/models/1/dlib_face_recognition_resnet_model_v1.dat')) {
-			return $this->appManager->getAppPath('facerecognition').'/models/1/dlib_face_recognition_resnet_model_v1.dat';
-		} else {
-			return NULL;
-		}
+		return $this->getModel1File('dlib_face_recognition_resnet_model_v1.dat');
 	}
 
 	public function getLandmarksModel ()
@@ -89,24 +80,27 @@ class Requirements
 	}
 
 	public function getLandmarksDetectionModelv2() {
-		if ($this->model !== 1) {
-			return NULL;
-		}
-
-		if (file_exists($this->appManager->getAppPath('facerecognition').'/models/1/shape_predictor_5_face_landmarks.dat')) {
-			return $this->appManager->getAppPath('facerecognition').'/models/1/shape_predictor_5_face_landmarks.dat';
-		} else {
-			return NULL;
-		}
+		return $this->getModel1File('shape_predictor_5_face_landmarks.dat');
 	}
 
 	public function getFaceDetectionModelv2() {
+		return $this->getModel1File('mmod_human_face_detector.dat');
+	}
+
+	/**
+	 * Common getter to full path, for all files from model with ID = 1
+	 *
+	 * @param string $file File to check
+	 * @return string|null Full path to file, or NULL if file is not found
+	 */
+	private function getModel1File(string $file) {
 		if ($this->model !== 1) {
 			return NULL;
 		}
 
-		if (file_exists($this->appManager->getAppPath('facerecognition').'/models/1/mmod_human_face_detector.dat')) {
-			return $this->appManager->getAppPath('facerecognition').'/models/1/mmod_human_face_detector.dat';
+		$fullPath = $this->appManager->getAppPath('facerecognition') . '/models/1/' . $file;
+		if (file_exists($fullPath)) {
+			return $fullPath;
 		} else {
 			return NULL;
 		}


### PR DESCRIPTION
There was couple of todos for this. Basically, idea was that task throw
exceptions on errors and that main event loop for tasks handle that.
Some tasks are already throwing exceptions, some are throwing now,
but yes - control flow should be with exceptions, not with return values.

I also tried to fix scrutinizer errors from files that I already modified.