### PR TITLE
Adding test for tasks and introducing integration tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,30 @@
+# Running tests
+
+All tests should be easily executed with simple:
+```
+make test
+```
+from root directory. However, you will not be able to execute integration tests out of the box, as they are modifying local instance. For those, you will have to explicitely export env variable:
+```
+export TRAVIS=1
+```
+to be able to run them. Again &ndash; make sure you are running test server and watch out as those tests can create havoc with your instance.
+
+Once you have all requirements satisified and you want to run test over and over again, it all boils down to calling:
+```
+phpunit -c phpunit.xml
+```
+from root directory. You can target specific tests with `--filter` etc., but this is all *regular* PHP unit testing, just type `phpunit -h` for more details.
+
+If you are missing PHPUnit, you can follow their [official guide](https://phpunit.de/getting-started/phpunit-7.html), but you should get binary with somwething like this:
+```
+wget -O phpunit https://phar.phpunit.de/phpunit-7.phar
+chmod +x phpunit
+./phpunit --version
+```
+
+# Writing tests
+
+As by standard definition, unit tests are not modifying external resources and should not touch database. If possible, you should try testing with unit tests, and if it not &ndash; add yourself to integration tests.
+
+Other than that, you are good to go &ndash; there are already some unit and integration tests in `tests/` directory, and you can always take a look at [Nextcloud unit testing official documentation](https://docs.nextcloud.com/server/14/developer_manual/core/unit-testing.html).

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,29 +1,32 @@
-# Running tests
+# Testing
+
+## Running tests
 
 All tests should be easily executed with simple:
-```
+```bash
 make test
 ```
 from root directory. However, you will not be able to execute integration tests out of the box, as they are modifying local instance. For those, you will have to explicitely export env variable:
-```
+```bash
 export TRAVIS=1
 ```
 to be able to run them. Again &ndash; make sure you are running test server and watch out as those tests can create havoc with your instance.
 
 Once you have all requirements satisified and you want to run test over and over again, it all boils down to calling:
-```
+```bash
 phpunit -c phpunit.xml
 ```
 from root directory. You can target specific tests with `--filter` etc., but this is all *regular* PHP unit testing, just type `phpunit -h` for more details.
 
 If you are missing PHPUnit, you can follow their [official guide](https://phpunit.de/getting-started/phpunit-7.html), but you should get binary with somwething like this:
-```
+
+```bash
 wget -O phpunit https://phar.phpunit.de/phpunit-7.phar
 chmod +x phpunit
 ./phpunit --version
 ```
 
-# Writing tests
+## Writing tests
 
 As by standard definition, unit tests are not modifying external resources and should not touch database. If possible, you should try testing with unit tests, and if it not &ndash; add yourself to integration tests.
 

--- a/lib/BackgroundJob/FaceRecognitionLogger.php
+++ b/lib/BackgroundJob/FaceRecognitionLogger.php
@@ -40,7 +40,7 @@ class FaceRecognitionLogger {
 	private $output;
 
 	public function __construct($logger) {
-		if ($logger instanceof ILogger) {
+		if (method_exists($logger, 'info') && method_exists($logger, 'debug')) {
 			$this->logger = $logger;
 		} else if ($logger instanceof OutputInterface) {
 			$this->output = $logger;

--- a/lib/BackgroundJob/Tasks/LockTask.php
+++ b/lib/BackgroundJob/Tasks/LockTask.php
@@ -44,7 +44,9 @@ class LockTask extends FaceRecognitionBackgroundTask {
 	 * @inheritdoc
 	 */
 	public function execute(FaceRecognitionContext $context) {
-		$lock_file = sys_get_temp_dir() . '/' . LOCK_FILENAME;
+		$this->setContext($context);
+
+		$lock_file = sys_get_temp_dir() . '/' . LockTask::LOCK_FILENAME;
 		$fp = fopen($lock_file, 'w');
 
 		if (!$fp || !flock($fp, LOCK_EX | LOCK_NB, $eWouldBlock) || $eWouldBlock) {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,9 @@
         <testsuite name="unit">
             <directory>./tests/unit</directory>
         </testsuite>
+        <testsuite name="integration">
+            <directory>./tests/integration</directory>
+        </testsuite>
     </testsuites>
     <filter>
         <whitelist>

--- a/tests/integration/AddMissingImagesTaskTest.php
+++ b/tests/integration/AddMissingImagesTaskTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017, Matias De lellis <mati86dl@gmail.com>
+ * @copyright Copyright (c) 2018, Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @author Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\FaceRecognition\Tests\Integration;
+
+use OC;
+use OC\Files\View;
+
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\AppFramework\App;
+use OCP\AppFramework\IAppContainer;
+
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionContext;
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionLogger;
+use OCA\FaceRecognition\BackgroundJob\Tasks\AddMissingImagesTask;
+
+use Test\TestCase;
+
+class AddMissingImagesTaskTest extends TestCase {
+	/** @var IAppContainer */
+	private $container;
+
+	/** @var FaceRecognitionContext Context */
+	private $context;
+
+	/** @var IUser User */
+	private $user;
+
+	/** @var IConfig Config */
+	private $config;
+
+	public function setUp() {
+		parent::setUp();
+		// Better safe than sorry. Warn user that database will be changed in chaotic manner:)
+		if (false === getenv('TRAVIS')) {
+			$this->fail("This test touches database. Add \"TRAVIS\" env variable if you want to run these test on your local instance.");
+		}
+
+		// Create user on which we will upload images and do testing
+		$userManager = OC::$server->getUserManager();
+		$this->user = $userManager->createUser('testuser' . rand(0, PHP_INT_MAX), 'password');
+
+		// Get container to get classes using DI
+		$app = new App('facerecognition');
+		$this->container = $app->getContainer();
+
+		// Insantiate our context, that all tasks need
+		$appManager = $this->container->query('OCP\App\IAppManager');
+		$userManager = $this->container->query('OCP\IUserManager');
+		$rootFolder = $this->container->query('OCP\Files\IRootFolder');
+		$this->config = $this->container->query('OCP\IConfig');
+		$logger = $this->container->query('OCP\ILogger');
+		$this->context = new FaceRecognitionContext($appManager, $userManager, $rootFolder, $this->config);
+		$this->context->logger = new FaceRecognitionLogger($logger);
+	}
+
+	public function tearDown() {
+		// TODO: Tracked with #32 - once we implement callback on user deletion,
+		// we need another test that drops images from database.
+		$this->user->delete();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that AddMissingImagesTask is updating app config that it finished full scan.
+	 * Note that, in this test, we cannot check number of newly found images,
+	 * as this instance might be in use and can lead to wrong results
+	 */
+	public function testFinishedFullScan() {
+		$this->doMissingImageScan();
+
+		$fullImageScanDone = $this->config->getAppValue('facerecognition', AddMissingImagesTask::FULL_IMAGE_SCAN_DONE_KEY, 'false');
+		$this->assertEquals('true', $fullImageScanDone);
+	}
+
+	/**
+	 * Test that, after one scan is done, next scan will not find any new images
+	 */
+	public function testNewScanIsEmpty() {
+		$imageMapper = $this->container->query('OCA\FaceRecognition\Db\ImageMapper');
+		$addMissingImagesTask = new AddMissingImagesTask($this->config, $imageMapper);
+
+		// Do it once, to make sure all images are inserted
+		$this->doMissingImageScan();
+		$fullImageScanDone = $this->config->getAppValue('facerecognition', AddMissingImagesTask::FULL_IMAGE_SCAN_DONE_KEY, 'false');
+		$this->assertEquals('true', $fullImageScanDone);
+
+		// Second time, there should be no newly inserted images
+		$this->doMissingImageScan();
+
+		$this->assertEquals(0, $this->context->propertyBag['AddMissingImagesTask_insertedImages']);
+		$this->assertEquals(0, count($imageMapper->findImagesWithoutFaces($this->user)));
+	}
+
+	/**
+	 * Test that empty crawling will do nothing
+	 */
+	public function testCrawlNoImages() {
+		$this->loginAsUser($this->user->getUID());
+		$view = new View('/' . $this->user->getUID() . '/files');
+		$view->file_put_contents("foo.txt", "content");
+
+		$this->doMissingImageScan($this->user);
+
+		$imageMapper = $this->container->query('OCA\FaceRecognition\Db\ImageMapper');
+		$this->assertEquals(0, count($imageMapper->findImagesWithoutFaces($this->user)));
+		$this->assertEquals(0, $this->context->propertyBag['AddMissingImagesTask_insertedImages']);
+	}
+
+	/**
+	 * Test that crawling with some images will actually find them and add them to database
+	 */
+	public function testCrawl() {
+		$this->loginAsUser($this->user->getUID());
+		$view = new View('/' . $this->user->getUID() . '/files');
+		$view->file_put_contents("foo1.txt", "content");
+		$view->file_put_contents("foo2.jpg", "content");
+		$view->file_put_contents("foo3.png", "content");
+		$view->mkdir('dir');
+		$view->file_put_contents("dir/foo4.txt", "content");
+		$view->file_put_contents("dir/foo5.bmp", "content");
+		$view->mkdir('dir_nomedia');
+		$view->file_put_contents("dir_nomedia/.nomedia", "content");
+		$view->file_put_contents("dir_nomedia/foo7.jpg", "content");
+
+		$this->doMissingImageScan($this->user);
+
+		// We should find 3 images only - foo2.jpg, foo3.png and dir/foo5.bmp
+		$imageMapper = $this->container->query('OCA\FaceRecognition\Db\ImageMapper');
+		$this->assertEquals(3, count($imageMapper->findImagesWithoutFaces($this->user)));
+		$this->assertEquals(3, $this->context->propertyBag['AddMissingImagesTask_insertedImages']);
+	}
+
+	/**
+	 * Helper method to set up and do scanning
+	 *
+	 * @* @param IUser|null $user Optional user to scan for. If not given, images for all users will be scanned.
+	 */
+	private function doMissingImageScan($user = null) {
+		// Reset config that full scan is done, to make sure we are scanning again
+		$this->config->setAppValue('facerecognition', AddMissingImagesTask::FULL_IMAGE_SCAN_DONE_KEY, 'false');
+
+		$imageMapper = $this->container->query('OCA\FaceRecognition\Db\ImageMapper');
+		$addMissingImagesTask = new AddMissingImagesTask($this->config, $imageMapper);
+
+		// Set user for which to do scanning, if any
+		$this->context->user = $user;
+
+		// Since this task returns generator, iterate until it is done
+		$generator = $addMissingImagesTask->execute($this->context);
+		foreach ($generator as $_) {
+		}
+
+		$this->assertEquals(true, $generator->getReturn());
+	}
+}

--- a/tests/integration/AddMissingImagesTaskTest.php
+++ b/tests/integration/AddMissingImagesTaskTest.php
@@ -99,7 +99,6 @@ class AddMissingImagesTaskTest extends TestCase {
 	 */
 	public function testNewScanIsEmpty() {
 		$imageMapper = $this->container->query('OCA\FaceRecognition\Db\ImageMapper');
-		$addMissingImagesTask = new AddMissingImagesTask($this->config, $imageMapper);
 
 		// Do it once, to make sure all images are inserted
 		$this->doMissingImageScan();

--- a/tests/integration/AppTest.php
+++ b/tests/integration/AppTest.php
@@ -21,37 +21,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-namespace OCA\FaceRecognition\BackgroundJob\Tasks;
+namespace OCA\FaceRecognition\Tests\Integration;
 
-use OCA\FaceRecognition\BackgroundJob\FaceRecognitionBackgroundTask;
-use OCA\FaceRecognition\BackgroundJob\FaceRecognitionContext;
+use OCP\AppFramework\App;
+use OCP\AppFramework\IAppContainer;
 
-/**
- * Task to unlock flock-ed file (and release mutex this way, so another background job can start).
- */
-class UnlockTask extends FaceRecognitionBackgroundTask {
-	/**
-	 * @inheritdoc
-	 */
-	public function description() {
-		return "Release obtained lock";
+use Test\TestCase;
+
+class AppTest extends TestCase {
+	/** @var IAppContainer */
+	private $container;
+
+	public function setUp() {
+		parent::setUp();
+		$app = new App('facerecognition');
+		$this->container = $app->getContainer();
 	}
 
-	/**
-	 * @inheritdoc
-	 */
-	public function execute(FaceRecognitionContext $context) {
-		if (!isset($context->propertyBag['lock'])) {
-			return false;
-		}
-
-		flock($context->propertyBag['lock'], LOCK_UN);
-
-		$lockFilename = $context->propertyBag['lock_filename'];
-		if (file_exists($lockFilename)) {
-			unlink($lockFilename);
-		}
-
-		return true;
+	public function testAppInstalled() {
+		$appManager = $this->container->query('OCP\App\IAppManager');
+		$this->assertTrue($appManager->isInstalled('facerecognition'));
 	}
 }

--- a/tests/unit/LockUnlockTaskTest.php
+++ b/tests/unit/LockUnlockTaskTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017, Matias De lellis <mati86dl@gmail.com>
+ * @copyright Copyright (c) 2018, Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @author Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\FaceRecognition\Tests\Unit;
+
+use OCP\IConfig;
+use OCP\ILogger;
+use OCP\IUserManager;
+
+use OCP\App\IAppManager;
+use OCP\Files\IRootFolder;
+
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionContext;
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionLogger;
+use OCA\FaceRecognition\BackgroundJob\Tasks\LockTask;
+use OCA\FaceRecognition\BackgroundJob\Tasks\UnlockTask;
+
+use Test\TestCase;
+
+class LockTaskTest extends TestCase {
+	/** @var FaceRecognitionContext Context */
+	private $context;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setUp() {
+		$appManager = $this->createMock(IAppManager::class);
+		$userManager = $this->createMock(IUserManager::class);
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$config = $this->createMock(IConfig::class);
+		$logger = $this->createMock(ILogger::class);
+		$this->context = new FaceRecognitionContext($appManager, $userManager, $rootFolder, $config);
+		$this->context->logger = new FaceRecognitionLogger($logger);
+	}
+
+	public function testLockUnlock() {
+		$lockTask = new LockTask();
+		$unlockTask = new UnlockTask();
+		$this->assertTrue($lockTask->execute($this->context));
+		$this->assertTrue($unlockTask->execute($this->context));
+	}
+
+	public function testDoubleLock() {
+		$lockTask = new LockTask();
+		$unlockTask = new UnlockTask();
+		$this->assertTrue($lockTask->execute($this->context));
+		$this->assertFalse($lockTask->execute($this->context));
+		$this->assertTrue($unlockTask->execute($this->context));
+	}
+
+	public function testEmptyUnlock() {
+		$unlockTask = new UnlockTask();
+		$this->assertFalse($unlockTask->execute($this->context));
+	}
+
+	public function testDoubleUnlock() {
+		$lockTask = new LockTask();
+		$unlockTask = new UnlockTask();
+		$this->assertTrue($lockTask->execute($this->context));
+		$this->assertTrue($unlockTask->execute($this->context));
+		// Double unlock is OK, nobody cares if second time we failed
+		$this->assertTrue($unlockTask->execute($this->context));
+	}
+}

--- a/tests/unit/MergeClustersTest.php
+++ b/tests/unit/MergeClustersTest.php
@@ -21,7 +21,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-namespace OCA\FaceRecognition\Tests;
+namespace OCA\FaceRecognition\Tests\Unit;
 
 use Test\TestCase;
 


### PR DESCRIPTION
This commit adds some tests for tasks. Lock and Unlock could be tested
with unit tests, but AddMissingImagesTask couldnt, so I added integration
tests which are using proper database. Other tests are blocked until we can
install PDLib in system. Also added TESTING.md (to remind me how to run tests:)