### PR TITLE
Adding logic to recreate existing clusters

### DIFF
--- a/lib/BackgroundJob/Tasks/CreateClustersTask.php
+++ b/lib/BackgroundJob/Tasks/CreateClustersTask.php
@@ -149,7 +149,7 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 			$this->logDebug(sprintf('Found %d stale persons for user %s and model %d', $stalePersonsCount, $userId, $modelId));
 			$haveStalePersons = $stalePersonsCount > 0;
 
-			if ($haveStalePersons == false && $haveNewFaces == false) {
+			if ($haveStalePersons === false && $haveNewFaces === false) {
 				// If there is no invalid persons, and there is no recent new faces, no need to recreate cluster
 				$this->logInfo('Clusters already exist, calculated there is no need to recreate them');
 				return;

--- a/lib/Db/FaceNew.php
+++ b/lib/Db/FaceNew.php
@@ -88,7 +88,7 @@ class FaceNew extends Entity implements JsonSerializable {
 	 *
 	 * @var \DateTime
 	 * */
-	public $creation_time;
+	public $creationTime;
 
 	/**
 	 * Factory method to create Face from face structure that is returned as output of the model.
@@ -106,7 +106,7 @@ class FaceNew extends Entity implements JsonSerializable {
 		$face->top = max($faceFromModel["top"], 0);
 		$face->bottom = $faceFromModel["bottom"];
 		$face->descriptor = array();
-		$face->creation_time = new \DateTime();
+		$face->creationTime = new \DateTime();
 		return $face;
 	}
 
@@ -150,11 +150,15 @@ class FaceNew extends Entity implements JsonSerializable {
 			'top' => $this->top,
 			'bottom' => $this->bottom,
 			'descriptor' => $this->descriptor,
-			'creation_time' => $this->creation_time
+			'creation_time' => $this->creationTime
 		];
 	}
 
 	public function setDescriptor($descriptor) {
 		$this->descriptor = json_decode($descriptor);
+	}
+
+	public function setCreationTime($creationTime) {
+		$this->creationTime = new \DateTime($creationTime);
 	}
 }

--- a/lib/Db/ImageMapper.php
+++ b/lib/Db/ImageMapper.php
@@ -192,7 +192,7 @@ class ImageMapper extends Mapper {
 						'top' => $qb->createNamedParameter($face->top),
 						'bottom' => $qb->createNamedParameter($face->bottom),
 						'descriptor' => $qb->createNamedParameter(json_encode($face->descriptor)),
-						'creation_time' => $qb->createNamedParameter($face->creation_time, IQueryBuilder::PARAM_DATE),
+						'creation_time' => $qb->createNamedParameter($face->creationTime, IQueryBuilder::PARAM_DATE),
 					])
 					->execute();
 			}


### PR DESCRIPTION
This logic was missing (without it, clusters will not get recreated when new images are added...)

I also had to refactor `creation_date` as `creationDate` (as Nextcloud expect that format when mapping from DB to class).

Also, WRT those magic numbers in code - let's not kid anyone, numbers are all pulled up from thin air, but they are good as sensible defaults:)