### PR TITLE
Dynamical image scaling, closes #59

### DIFF
--- a/lib/BackgroundJob/Tasks/ImageProcessingTask.php
+++ b/lib/BackgroundJob/Tasks/ImageProcessingTask.php
@@ -226,7 +226,7 @@ class ImageProcessingTask extends FaceRecognitionBackgroundTask {
 		// Based on amount on memory PHP have, we will determine maximum amount of image size that we need to scale to.
 		// This reasoning and calculations are all based on analysis given here:
 		// https://github.com/matiasdelellis/facerecognition/wiki/Performance-analysis-of-DLib%E2%80%99s-CNN-face-detection
-		$allowedMemory = $context->propertyBag['memory'];
+		$allowedMemory = $this->$context->propertyBag['memory'];
 		$maxImageArea = intval($allowedMemory / 1024); // in pixels^2
 		$ratio = $this->resizeImage($image, $maxImageArea);
 

--- a/lib/BackgroundJob/Tasks/ImageProcessingTask.php
+++ b/lib/BackgroundJob/Tasks/ImageProcessingTask.php
@@ -226,7 +226,7 @@ class ImageProcessingTask extends FaceRecognitionBackgroundTask {
 		// Based on amount on memory PHP have, we will determine maximum amount of image size that we need to scale to.
 		// This reasoning and calculations are all based on analysis given here:
 		// https://github.com/matiasdelellis/facerecognition/wiki/Performance-analysis-of-DLib%E2%80%99s-CNN-face-detection
-		$allowedMemory = $this->$context->propertyBag['memory'];
+		$allowedMemory = $this->context->propertyBag['memory'];
 		$maxImageArea = intval($allowedMemory / 1024); // in pixels^2
 		$ratio = $this->resizeImage($image, $maxImageArea);
 

--- a/lib/Helper/MemoryLimits.php
+++ b/lib/Helper/MemoryLimits.php
@@ -108,6 +108,6 @@ class MemoryLimits {
 				$val *= 1024;
 		}
 
-		return $val;
+		return intval($val);
 	}
 }

--- a/lib/Helper/MemoryLimits.php
+++ b/lib/Helper/MemoryLimits.php
@@ -65,6 +65,10 @@ class MemoryLimits {
 
 	private static function getTotalMemoryLinux(): int {
 		$fh = fopen('/proc/meminfo','r');
+		if ($fh === false) {
+			return 0;
+		}
+
 		$mem = 0;
 		while ($line = fgets($fh)) {
 			$pieces = array();
@@ -82,7 +86,7 @@ class MemoryLimits {
 	 * Converts shorthand memory notation value to bytes
 	 * From http://php.net/manual/en/function.ini-get.php
 	 *
-	 * @param string val Memory size shorthand notation string
+	 * @param string $val Memory size shorthand notation string
 	 *
 	 * @return int Value in integers (bytes)
 	 */
@@ -94,11 +98,12 @@ class MemoryLimits {
 
 		$last = strtolower($val[strlen($val)-1]);
 		switch($last) {
-			// Fallthrough on purpose
 			case 'g':
 				$val *= 1024;
+				// Fallthrough on purpose
 			case 'm':
 				$val *= 1024;
+				// Fallthrough on purpose
 			case 'k':
 				$val *= 1024;
 		}

--- a/lib/Helper/MemoryLimits.php
+++ b/lib/Helper/MemoryLimits.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017, Matias De lellis <mati86dl@gmail.com>
+ * @copyright Copyright (c) 2018, Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @author Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\FaceRecognition\Helper;
+
+/**
+ * Tries to get total amount of memory on the host, given to PHP.
+ */
+class MemoryLimits {
+
+	/**
+	 * Tries to get memory available to PHP. This is highly speculative business.
+	 * It will first try reading value of "memory_limit" and if it is -1, it will
+	 * try to get 1/2 memory of host system. In case of any error, it will return
+	 * negative value. Note that negative here doesn't mean "unlimited"! This
+	 * function doesn't care if PHP is being used in CLI or FPM mode.
+	 *
+	 * @return int Total memory available to PHP, in bytes, or negative if
+	 * we don't know any better
+	 */
+	public static function getAvailableMemory(): int {
+		// Try first to get from php.ini
+		try {
+			$value = MemoryLimits::returnBytes(ini_get('memory_limit'));
+			if ($value > 0) {
+				return $value;
+			}
+		} catch (\Exception $e) {
+			return -1;
+		}
+
+		// php.ini says that memory_limit is -1, which means unlimited.
+		//We need to get memory from system (if system is supported here).
+		// Only linux is currently supported.
+		if (php_uname("s") === "Linux") {
+			$linuxMemory = MemoryLimits::getTotalMemoryLinux();
+			if ($linuxMemory <= 0) {
+				return -3;
+			}
+			return intval($linuxMemory / 2);
+		} else {
+			return -2;
+		}
+	}
+
+	private static function getTotalMemoryLinux(): int {
+		$fh = fopen('/proc/meminfo','r');
+		$mem = 0;
+		while ($line = fgets($fh)) {
+			$pieces = array();
+			if (preg_match('/^MemTotal:\s+(\d+)\skB$/', $line, $pieces)) {
+				$mem = $pieces[1];
+				break;
+			}
+		}
+		fclose($fh);
+		$memKb = intval($mem);
+		return $memKb * 1024;
+	}
+
+	/**
+	 * Converts shorthand memory notation value to bytes
+	 * From http://php.net/manual/en/function.ini-get.php
+	 *
+	 * @param string val Memory size shorthand notation string
+	 *
+	 * @return int Value in integers (bytes)
+	 */
+	private static function returnBytes(string $val): int {
+		$val = trim($val);
+		if ($val === "") {
+			return 0;
+		}
+
+		$last = strtolower($val[strlen($val)-1]);
+		switch($last) {
+			// Fallthrough on purpose
+			case 'g':
+				$val *= 1024;
+			case 'm':
+				$val *= 1024;
+			case 'k':
+				$val *= 1024;
+		}
+
+		return $val;
+	}
+}

--- a/tests/unit/ResizeTest.php
+++ b/tests/unit/ResizeTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017, Matias De lellis <mati86dl@gmail.com>
+ * @copyright Copyright (c) 2018, Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @author Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\FaceRecognition\Tests\Unit;
+
+use OC_Image;
+
+use OCP\IConfig;
+use OCP\ILogger;
+use OCP\ITempManager;
+use OCP\IUserManager;
+
+use OCP\App\IAppManager;
+use OCP\Files\IRootFolder;
+
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionContext;
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionLogger;
+use OCA\FaceRecognition\BackgroundJob\Tasks\ImageProcessingTask;
+use OCA\FaceRecognition\Db\ImageMapper;
+
+use Test\TestCase;
+
+class ResizeTest extends TestCase {
+	/** @var FaceRecognitionContext Context */
+	private $context;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setUp() {
+		$appManager = $this->createMock(IAppManager::class);
+		$userManager = $this->createMock(IUserManager::class);
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$config = $this->createMock(IConfig::class);
+		$logger = $this->createMock(ILogger::class);
+		$this->context = new FaceRecognitionContext($appManager, $userManager, $rootFolder, $config);
+		$this->context->logger = new FaceRecognitionLogger($logger);
+	}
+
+	public function testResize() {
+		$config = $this->createMock(IConfig::class);
+		$imageMapper = $this->createMock(ImageMapper::class);
+		$tempManager = $this->createMock(ITempManager::class);
+		$imageProcessingTask = new ImageProcessingTask($config, $imageMapper, $tempManager);
+		$image = new OC_Image();
+
+		// Try when there is no change
+		$image->setResource(imagecreate(100, 100));
+		$ratio = $imageProcessingTask->resizeImage($image, 100 * 100);
+		$this->assertEquals(1, $ratio);
+		$this->assertEquals(100, imagesx($image->resource()));
+		$this->assertEquals(100, imagesy($image->resource()));
+		// This image need double scaling up
+		$image->setResource(imagecreate(100, 100));
+		$ratio = $imageProcessingTask->resizeImage($image, 200 * 200);
+		$this->assertEquals(1/2, $ratio);
+		$this->assertEquals(200, imagesx($image->resource()));
+		$this->assertEquals(200, imagesy($image->resource()));
+		// This image need double scaling down
+		$image->setResource(imagecreate(200, 200));
+		$ratio = $imageProcessingTask->resizeImage($image, 100 * 100);
+		$this->assertEquals(2, $ratio);
+		$this->assertEquals(100, imagesx($image->resource()));
+		$this->assertEquals(100, imagesy($image->resource()));
+		// No change and ratio is different
+		$image->setResource(imagecreate(200, 50));
+		$ratio = $imageProcessingTask->resizeImage($image, 200 * 50);
+		$this->assertEquals(1, $ratio);
+		$this->assertEquals(200, imagesx($image->resource()));
+		$this->assertEquals(50, imagesy($image->resource()));
+		// Scaling up 3.5 times and ratio is different
+		$image->setResource(imagecreate(200, 30));
+		$ratio = $imageProcessingTask->resizeImage($image, 200 * 30 * 3.5 * 3.5);
+		$this->assertEquals(1/3.5, $ratio);
+		$this->assertEquals(200 * 3.5, imagesx($image->resource()));
+		$this->assertEquals(30 * 3.5, imagesy($image->resource()));
+		// Scaling down 4x
+		$image->setResource(imagecreate(40, 300));
+		$ratio = $imageProcessingTask->resizeImage($image, (40 * 300) / (4 * 4));
+		$this->assertEquals(4, $ratio);
+		$this->assertEquals(40 /4, imagesx($image->resource()));
+		$this->assertEquals(300 / 4, imagesy($image->resource()));
+	}
+}


### PR DESCRIPTION
This is implementation of out discussion in #59. It still missing some stuff, like:
* ability for user to manually choose quality (if I have 8GB, I don't want to use "only" 4GB, if I can tell 6GB)
* resiliency to OOM
* GPU calculation (if I have GPU, DLib do not care if I have 4GB or 8GB - this requires some changes in pdlib, I think)
* Windows/Mac/BSD do not have implementation to get system memory

I will create separate issues for all of these, but only "OOM ressiliency" is important for release, IMHO