### PR TITLE
Fixing #67 and lowering memory limits to 3/4

### DIFF
--- a/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
+++ b/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
@@ -84,6 +84,9 @@ class CheckRequirementsTask extends FaceRecognitionBackgroundTask {
 			// TODO: allow user to choose "recognition quality", which will map to given memory.
 			// If user explicitely set something, we ignore getting memory from system.
 			$memory = 1024 * 1024 * 1024;
+		} else {
+			// No point going above 4GB ("4GB should be enough for everyone")
+			$memory = min($memory, 4 * 1024 * 1024 * 1024);
 		}
 
 		$context->propertyBag['memory'] = $memory;

--- a/lib/BackgroundJob/Tasks/CreateClustersTask.php
+++ b/lib/BackgroundJob/Tasks/CreateClustersTask.php
@@ -164,7 +164,10 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 			// todo: 2 queries to get these 2 counts, can we do this smarter?
 			$imageCount = $this->imageMapper->countUserImages($userId, $modelId);
 			$imageProcessed = $this->imageMapper->countUserProcessedImages($userId, $modelId);
-			$percentImagesProcessed = $imageProcessed / floatval($imageCount);
+			$percentImagesProcessed = 0;
+			if ($imageCount > 0) {
+				$percentImagesProcessed = $imageProcessed / floatval($imageCount);
+			}
 			$facesCount = $this->faceMapper->countFaces($userId, $modelId);
 			// todo: get rid of magic numbers (move to config)
 			if (($facesCount < 1000) && ($imageCount < 100) && ($percentImagesProcessed < 0.95)) {

--- a/lib/BackgroundJob/Tasks/ImageProcessingTask.php
+++ b/lib/BackgroundJob/Tasks/ImageProcessingTask.php
@@ -197,7 +197,7 @@ class ImageProcessingTask extends FaceRecognitionBackgroundTask {
 		// Convert from dictionary of faces to our Face Db Entity
 		$faces = array();
 		foreach ($facesFound as $faceFound) {
-			$face = Face::fromModel($image, $faceFound);
+			$face = Face::fromModel($image->getId(), $faceFound);
 			$face->normalizeSize($imageProcessingContext->getRatio());
 			$faces[] = $face;
 		}
@@ -227,7 +227,7 @@ class ImageProcessingTask extends FaceRecognitionBackgroundTask {
 		// This reasoning and calculations are all based on analysis given here:
 		// https://github.com/matiasdelellis/facerecognition/wiki/Performance-analysis-of-DLib%E2%80%99s-CNN-face-detection
 		$allowedMemory = $this->context->propertyBag['memory'];
-		$maxImageArea = intval($allowedMemory / 1024); // in pixels^2
+		$maxImageArea = intval((0.75 * $allowedMemory) / 1024); // in pixels^2
 		$ratio = $this->resizeImage($image, $maxImageArea);
 
 		$tempfile = $this->tempManager->getTemporaryFile(pathinfo($imagePath, PATHINFO_EXTENSION));

--- a/lib/Db/Face.php
+++ b/lib/Db/Face.php
@@ -98,10 +98,10 @@ class Face extends Entity implements JsonSerializable {
 	 * Factory method to create Face from face structure that is returned as output of the model.
 	 *
 	 * @param int $image Image Id
-	 * @param dict $faceFromModel Face obtained from DNN model
+	 * @param array $faceFromModel Face obtained from DNN model
 	 * @return Face Created face
 	 */
-	public static function fromModel($image, $faceFromModel): Face {
+	public static function fromModel(int $image, array $faceFromModel): Face {
 		$face = new Face();
 		$face->image = $image;
 		$face->person = null;

--- a/lib/Helper/MemoryLimits.php
+++ b/lib/Helper/MemoryLimits.php
@@ -90,24 +90,29 @@ class MemoryLimits {
 	 *
 	 * @return int Value in integers (bytes)
 	 */
-	private static function returnBytes(string $val): int {
+	public static function returnBytes(string $val): int {
 		$val = trim($val);
 		if ($val === "") {
+			return 0;
+		}
+
+		$valInt = intval($val);
+		if ($valInt === 0) {
 			return 0;
 		}
 
 		$last = strtolower($val[strlen($val)-1]);
 		switch($last) {
 			case 'g':
-				$val *= 1024;
+				$valInt *= 1024;
 				// Fallthrough on purpose
 			case 'm':
-				$val *= 1024;
+				$valInt *= 1024;
 				// Fallthrough on purpose
 			case 'k':
-				$val *= 1024;
+				$valInt *= 1024;
 		}
 
-		return intval($val);
+		return $valInt;
 	}
 }

--- a/tests/unit/MemoryLimitsTest.php
+++ b/tests/unit/MemoryLimitsTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017, Matias De lellis <mati86dl@gmail.com>
+ * @copyright Copyright (c) 2018, Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @author Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\FaceRecognition\Tests\Unit;
+
+use OCA\FaceRecognition\Helper\MemoryLimits;
+
+use Test\TestCase;
+
+class MemoryLimitsTest extends TestCase {
+
+	public function testReturnBytes() {
+		$this->assertEquals(0, MemoryLimits::returnBytes(''));
+		$this->assertEquals(0, MemoryLimits::returnBytes('foo'));
+		$this->assertEquals(0, MemoryLimits::returnBytes('foo100'));
+		$this->assertEquals(100, MemoryLimits::returnBytes('100'));
+		$this->assertEquals(100, MemoryLimits::returnBytes('100fgh'));
+		$this->assertEquals(101 * 1024, MemoryLimits::returnBytes('101K'));
+		$this->assertEquals(102 * 1024 * 1024, MemoryLimits::returnBytes('102M'));
+		$this->assertEquals(103 * 1024 * 1024 * 1024, MemoryLimits::returnBytes('103g'));
+	}
+}


### PR DESCRIPTION
This is trying to fix #67:
* fixed create cluster division by 0
* fixed wrong type for `Face::fromModel`
* lowered memory requirement to 3/4 of what was it before (1GB was enough for 1024x1024px, now it is enough "only" for 1024x768px)
* Upper bound for memory is 4GB (if user have more than that, it is ignore, it is not contributing to quality, just increases time to recognize faces)
* I don't think `returnBytes` was problem, because that warning (that you are seeing @matiasdelellis ) are just that - warnings, but code was more or less working (altough it is weird multplying int and string:). So, I *think* this is not what was causing problem for you, I think OOM & other stuff together was more likely. I did correct types in that function to fix warning (and because I am embrassed🙁)

Basically, I am not quite sure if this fixes everything, but please @matiasdelellis try it out when you find time with these fixes!