### PR TITLE
Implement stale image removal task, fixes #37

### DIFF
--- a/lib/BackgroundJob/BackgroundService.php
+++ b/lib/BackgroundJob/BackgroundService.php
@@ -28,13 +28,14 @@ use OCP\IUser;
 use OCA\FaceRecognition\AppInfo\Application;
 use OCA\FaceRecognition\Helper\Requirements;
 
+use OCA\FaceRecognition\BackgroundJob\Tasks\AddMissingImagesTask;
 use OCA\FaceRecognition\BackgroundJob\Tasks\CheckCronTask;
 use OCA\FaceRecognition\BackgroundJob\Tasks\CheckRequirementsTask;
-use OCA\FaceRecognition\BackgroundJob\Tasks\LockTask;
 use OCA\FaceRecognition\BackgroundJob\Tasks\CreateClustersTask;
-use OCA\FaceRecognition\BackgroundJob\Tasks\AddMissingImagesTask;
 use OCA\FaceRecognition\BackgroundJob\Tasks\EnumerateImagesMissingFacesTask;
 use OCA\FaceRecognition\BackgroundJob\Tasks\ImageProcessingTask;
+use OCA\FaceRecognition\BackgroundJob\Tasks\LockTask;
+use OCA\FaceRecognition\BackgroundJob\Tasks\StaleImagesRemovalTask;
 use OCA\FaceRecognition\BackgroundJob\Tasks\UnlockTask;
 
 use Symfony\Component\Console\Output\OutputInterface;
@@ -90,6 +91,7 @@ class BackgroundService {
 			CheckRequirementsTask::class,
 			CheckCronTask::class,
 			LockTask::class,
+			StaleImagesRemovalTask::class,
 			CreateClustersTask::class,
 			AddMissingImagesTask::class,
 			EnumerateImagesMissingFacesTask::class,

--- a/lib/BackgroundJob/Tasks/AddMissingImagesTask.php
+++ b/lib/BackgroundJob/Tasks/AddMissingImagesTask.php
@@ -106,8 +106,6 @@ class AddMissingImagesTask extends FaceRecognitionBackgroundTask {
 
 	/**
 	 * Crawl filesystem for a given user
-	 * TODO: duplicated from Queue.php, figure out how to merge
-	 * (or delete this Queue.php when not needed)
 	 *
 	 * @param string $userId ID of the user for which to crawl images for
 	 * @param int $model Used model

--- a/lib/BackgroundJob/Tasks/StaleImagesRemovalTask.php
+++ b/lib/BackgroundJob/Tasks/StaleImagesRemovalTask.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017, Matias De lellis <mati86dl@gmail.com>
+ * @copyright Copyright (c) 2018, Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @author Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\FaceRecognition\BackgroundJob\Tasks;
+
+use OCP\IConfig;
+use OCP\IUser;
+
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\IHomeStorage;
+
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionBackgroundTask;
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionContext;
+use OCA\FaceRecognition\Db\Image;
+use OCA\FaceRecognition\Db\ImageMapper;
+use OCA\FaceRecognition\Db\FaceMapper;
+use OCA\FaceRecognition\Db\PersonMapper;
+use OCA\FaceRecognition\Migration\AddDefaultFaceModel;
+
+/**
+ * Task that, for each user, crawls for all images in database,
+ * checks if they actually exist and removes them if they don't.
+ * It should be executed rarely.
+ */
+class StaleImagesRemovalTask extends FaceRecognitionBackgroundTask {
+	const STALE_IMAGES_REMOVAL_NEEDED_KEY = "stale_images_removal_needed";
+	const STALE_IMAGES_LAST_CHECKED_KEY = "stale_images_last_checked";
+
+	/** @var IConfig Config */
+	private $config;
+
+	/** @var ImageMapper Image mapper */
+	private $imageMapper;
+
+	/** @var FaceMapper Face mapper */
+	private $faceMapper;
+
+	/** @var PersonMapper Person mapper */
+	private $personMapper;
+
+	/**
+	 * @param IConfig $config Config
+	 * @param ImageMapper $imageMapper Image mapper
+	 * @param FaceMapper $faceMapper Face mapper
+	 * @param PersonMapper $personMapper Person mapper
+	 */
+	public function __construct(IConfig $config, ImageMapper $imageMapper, FaceMapper $faceMapper, PersonMapper $personMapper) {
+		parent::__construct();
+		$this->config = $config;
+		$this->imageMapper = $imageMapper;
+		$this->faceMapper = $faceMapper;
+		$this->personMapper = $personMapper;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function description() {
+		return "Crawl for stale images (either missing in filesystem or under .nomedia) and remove them from DB";
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function execute(FaceRecognitionContext $context) {
+		$this->setContext($context);
+
+		$model = intval($this->config->getAppValue('facerecognition', 'model', AddDefaultFaceModel::DEFAULT_FACE_MODEL_ID));
+
+		// Check if we are called for one user only, or for all user in instance.
+		$staleRemovedImages = 0;
+		$eligable_users = array();
+		if (is_null($this->context->user)) {
+			$this->context->userManager->callForSeenUsers(function (IUser $user) use (&$eligable_users) {
+				$eligable_users[] = $user->getUID();
+			});
+		} else {
+			$eligable_users[] = $this->context->user->getUID();
+		}
+
+		foreach($eligable_users as $user) {
+			$staleImagesRemovalNeeded = $this->config->getUserValue(
+				$user, 'facerecognition', StaleImagesRemovalTask::STALE_IMAGES_REMOVAL_NEEDED_KEY, 'false');
+			if ($staleImagesRemovalNeeded === 'false') {
+				// Completely skip this task for this user, seems that we already did full scan for him
+				$this->logDebug(sprintf('Skipping stale images removal for user %s as there is no need for it', $user));
+				continue;
+			}
+
+			// Since method below can take long time, it is generator itself
+			$generator = $this->staleImagesRemovalForUser($user, $model);
+			foreach ($generator as $_) {
+				yield;
+			}
+			$staleRemovedImages += $generator->getReturn();
+
+			$this->config->setUserValue($user, 'facerecognition', StaleImagesRemovalTask::STALE_IMAGES_REMOVAL_NEEDED_KEY, 'false');
+			yield;
+		}
+
+		$this->context->propertyBag['StaleImagesRemovalTask_staleRemovedImages'] = $staleRemovedImages;
+		return true;
+	}
+
+	/**
+	 * Gets all images in database for a given user. For each image, check if it
+	 * actually present in filesystem (and there is no .nomedia for it) and removes
+	 * it from database if it is not present.
+	 *
+	 * @param string $userId ID of the user for which to remove stale images for
+	 * @param int $model Used model
+	 * @return \Generator|int Returns generator during yielding and finally returns int,
+	 * which represent number of stale images removed
+	 */
+	private function staleImagesRemovalForUser(string $userId, int $model) {
+		\OC_Util::tearDownFS();
+		\OC_Util::setupFS($userId);
+
+		$this->logDebug(sprintf('Getting all images for user %s', $userId));
+		$allImages = $this->imageMapper->findImages($userId, $model);
+		$this->logDebug(sprintf('Found %d images for user %s', count($allImages), $userId));
+		yield;
+
+		// Find if we stopped somewhere abruptly before. If we are, we need to start from that point.
+		// If there is value, we start from beggining. Important is that:
+		// * There needs to be some (any!) ordering here, we used "id" for ordering key
+		// * New images will be processed, or some might be checked more than once, and that is OK
+		//   Important part is that we make continuous progess.
+		$lastChecked = intval($this->config->getUserValue(
+			$userId, 'facerecognition', StaleImagesRemovalTask::STALE_IMAGES_LAST_CHECKED_KEY, '0'));
+		$this->logDebug(sprintf('Last checked image id for user %s is %d', $userId, $lastChecked));
+		yield;
+
+		// Now filter by those above last checked and sort remaining images
+		$allImages = array_filter($allImages, function ($i) use($lastChecked) {
+			return $i->id > $lastChecked;
+		});
+		usort($allImages, function ($i1, $i2) {
+			return $i1->id <=> $i2->id;
+		});
+		$this->logDebug(sprintf(
+			'After filtering and sorting, there is %d remaining stale images to check for user %s',
+			count($allImages), $userId));
+		yield;
+
+		// Now iterate and check remaining images
+		$userFolder = $this->context->rootFolder->getUserFolder($userId);
+		$processed = 0;
+		$imagesRemoved = 0;
+		foreach ($allImages as $image) {
+			// Delete image doesn't exist anymore in filesystem or it is under .nomedia
+			$mount = $this->getHomeMount($userFolder, $image);
+
+			if ($mount === null) {
+				$this->deleteImage($image, $userId);
+				$imagesRemoved++;
+			} else if ($this->isUnderNoMedia($mount)) {
+				$this->deleteImage($image, $userId);
+				$imagesRemoved++;
+			}
+
+			// Remember last processed image
+			$this->config->setUserValue(
+				$userId, 'facerecognition', StaleImagesRemovalTask::STALE_IMAGES_LAST_CHECKED_KEY, $image->id);
+
+			// Yield from time to time
+			$processed++;
+			if ($processed % 10 == 0) {
+				$this->logDebug(sprintf('Processed %d/%d stale images for user %s', $processed, count($allImages), $userId));
+				yield;
+			}
+		}
+
+		// Remove this value when we are done, so next cleanup can start from 0
+		$this->config->deleteUserValue($userId, 'facerecognition', StaleImagesRemovalTask::STALE_IMAGES_LAST_CHECKED_KEY);
+		return $imagesRemoved;
+	}
+
+	/**
+	 * For a given image, tries to find home mount. Returns null if it is not found (equivalent of image does not exist).
+	 *
+	 * @param Folder $userFolder User folder to search in
+	 * @param Image $image Image to find home mount for
+	 *
+	 * @return File|null File if image file node is found, null otherwise.
+	 */
+	private function getHomeMount(Folder $userFolder, Image $image) {
+		$allMounts = $userFolder->getById($image->file);
+		$homeMounts = array_filter($allMounts, function ($m) {
+			return $m->getStorage()->instanceOfStorage(IHomeStorage::class);
+		});
+
+		if (count($homeMounts) === 0) {
+			return null;
+		} else {
+			return $homeMounts[0];
+		}
+	}
+
+	/**
+	 * Checks if this file is located somewhere under .nomedia file and should be therefore ignored.
+	 * TODO: same method is in Watcher.php, find a place for both methods
+	 *
+	 * @param File $file File to search for
+	 * @return bool True if file is located under .nomedia, false otherwise
+	 */
+	private function isUnderNoMedia(File $file): bool {
+		// If we detect .nomedia file anywhere on the path to root folder (id===null), bail out
+		$parentNode = $file->getParent();
+		while (($parentNode instanceof Folder) && ($parentNode->getId() !== null)) {
+			if ($parentNode->nodeExists('.nomedia')) {
+				return true;
+			}
+			$parentNode = $parentNode->getParent();
+		}
+
+		return false;
+	}
+
+	private function deleteImage(Image $image, string $userId) {
+		$this->logInfo(sprintf('Removing stale image %d for user %s', $image->id, $userId));
+		// note that invalidatePersons depends on existence of faces for a given image,
+		// and we must invalidate before we delete faces!
+		// TODO: this is same method as in Watcher, find where to unify them.
+		$this->personMapper->invalidatePersons($image->id);
+		$this->faceMapper->removeFaces($image->id);
+		$this->imageMapper->delete($image);
+	}
+}

--- a/lib/Db/ImageMapper.php
+++ b/lib/Db/ImageMapper.php
@@ -36,7 +36,7 @@ class ImageMapper extends QBMapper {
 		parent::__construct($db, 'face_recognition_images', '\OCA\FaceRecognition\Db\Image');
 	}
 
-	public function find (string $userId, int $imageId): Image {
+	public function find(string $userId, int $imageId): Image {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('id', 'file')
 			->from('face_recognition_images', 'i')
@@ -175,6 +175,16 @@ class ImageMapper extends QBMapper {
 		return $images;
 	}
 
+	public function findImages(string $userId, int $model): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('i.id', 'i.file')
+			->from($this->getTableName(), 'i')
+			->where($qb->expr()->eq('user', $qb->createNamedParameter($userId)))
+			->andWhere($qb->expr()->eq('model', $qb->createNamedParameter($model)));
+
+		$images = $this->findEntities($qb);
+		return $images;
+	}
 
 	public function findImagesFromPerson(string $userId, string $name, int $model): array {
 		$qb = $this->db->getQueryBuilder();

--- a/lib/Db/PersonMapper.php
+++ b/lib/Db/PersonMapper.php
@@ -116,14 +116,15 @@ class PersonMapper extends QBMapper {
 	 */
 	public function invalidatePersons(int $imageId) {
 		$sub = $this->db->getQueryBuilder();
+		$tableNameWithPrefixWithoutQuotes = trim($sub->getTableName($this->getTableName()), '`');
 		$sub->select(new Literal('1'));
 		$sub->from("face_recognition_images", "i")
 			->innerJoin('i', 'face_recognition_faces' ,'f', $sub->expr()->eq('i.id', 'f.image'))
-			->where($sub->expr()->eq('p.id', 'f.person'))
+			->where($sub->expr()->eq($tableNameWithPrefixWithoutQuotes . '.id', 'f.person'))
 			->andWhere($sub->expr()->eq('i.id', $sub->createParameter('image_id')));
 
 		$qb = $this->db->getQueryBuilder();
-		$qb->update($this->getTableName(), 'p')
+		$qb->update($this->getTableName())
 			->set("is_valid", $qb->createParameter('is_valid'))
 			->where('EXISTS (' . $sub->getSQL() . ')')
 			->setParameter('image_id', $imageId)

--- a/tests/integration/AddMissingImagesTaskTest.php
+++ b/tests/integration/AddMissingImagesTaskTest.php
@@ -155,7 +155,7 @@ class AddMissingImagesTaskTest extends TestCase {
 	/**
 	 * Helper method to set up and do scanning
 	 *
-	 * @* @param IUser|null $contextUser Optional user to scan for. If not given, images for all users will be scanned.
+	 * @param IUser|null $contextUser Optional user to scan for. If not given, images for all users will be scanned.
 	 */
 	private function doMissingImageScan($contextUser = null) {
 		// Reset config that full scan is done, to make sure we are scanning again

--- a/tests/integration/StaleImagesRemovalTaskTest.php
+++ b/tests/integration/StaleImagesRemovalTaskTest.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017, Matias De lellis <mati86dl@gmail.com>
+ * @copyright Copyright (c) 2018, Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @author Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\FaceRecognition\Tests\Integration;
+
+use OC;
+use OC\Files\View;
+
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\AppFramework\App;
+use OCP\AppFramework\IAppContainer;
+
+use OCA\FaceRecognition\Db\Image;
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionContext;
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionLogger;
+use OCA\FaceRecognition\BackgroundJob\Tasks\AddMissingImagesTask;
+use OCA\FaceRecognition\BackgroundJob\Tasks\StaleImagesRemovalTask;
+use OCA\FaceRecognition\Migration\AddDefaultFaceModel;
+
+use Test\TestCase;
+
+class StaleImagesRemovalTaskTest extends TestCase {
+	/** @var IAppContainer */
+	private $container;
+
+	/** @var FaceRecognitionContext Context */
+	private $context;
+
+	/** @var IUser User */
+	private $user;
+
+	/** @var IConfig Config */
+	private $config;
+
+	public function setUp() {
+		parent::setUp();
+		// Better safe than sorry. Warn user that database will be changed in chaotic manner:)
+		if (false === getenv('TRAVIS')) {
+			$this->fail("This test touches database. Add \"TRAVIS\" env variable if you want to run these test on your local instance.");
+		}
+
+		// Create user on which we will upload images and do testing
+		$userManager = OC::$server->getUserManager();
+		$username = 'testuser' . rand(0, PHP_INT_MAX);
+		$this->user = $userManager->createUser($username, 'password');
+		$this->loginAsUser($username);
+		// Get container to get classes using DI
+		$app = new App('facerecognition');
+		$this->container = $app->getContainer();
+
+		// Insantiate our context, that all tasks need
+		$appManager = $this->container->query('OCP\App\IAppManager');
+		$userManager = $this->container->query('OCP\IUserManager');
+		$rootFolder = $this->container->query('OCP\Files\IRootFolder');
+		$this->config = $this->container->query('OCP\IConfig');
+		$logger = $this->container->query('OCP\ILogger');
+		$this->context = new FaceRecognitionContext($appManager, $userManager, $rootFolder, $this->config);
+		$this->context->logger = new FaceRecognitionLogger($logger);
+	}
+
+	public function tearDown() {
+		// TODO: Tracked with #32 - once we implement callback on user deletion,
+		// we need another test that drops images from database.
+		$this->user->delete();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that StaleImagesRemovalTask is not active, even though there should be some removals.
+	 */
+	public function testNotNeededScan() {
+		$imageMapper = $this->container->query('OCA\FaceRecognition\Db\ImageMapper');
+		$image = new Image();
+		$image->setUser($this->user->getUid());
+		$image->setFile(1);
+		$image->setModel(AddDefaultFaceModel::DEFAULT_FACE_MODEL_ID);
+		$imageMapper->insert($image);
+
+		$staleImagesRemovalTask = $this->createStaleImagesRemovalTask();
+		$generator = $staleImagesRemovalTask->execute($this->context);
+		foreach ($generator as $_) {
+		}
+		$this->assertEquals(true, $generator->getReturn());
+
+		$this->assertEquals(0, $this->context->propertyBag['StaleImagesRemovalTask_staleRemovedImages']);
+		$imageMapper->delete($image);
+	}
+
+	/**
+	 * Test that image which exists only in database is removed when StaleImagesRemovalTask is run.
+	 */
+	public function testMissingImageRemoval() {
+		$imageMapper = $this->container->query('OCA\FaceRecognition\Db\ImageMapper');
+		$image = new Image();
+		$image->setUser($this->user->getUid());
+		$image->setFile(2);
+		$image->setModel(AddDefaultFaceModel::DEFAULT_FACE_MODEL_ID);
+		$imageMapper->insert($image);
+
+		$this->doStaleImagesRemoval();
+		$this->assertEquals(1, $this->context->propertyBag['StaleImagesRemovalTask_staleRemovedImages']);
+	}
+
+	/**
+	 * Test that image under .nomedia directory is removed
+	 */
+	public function testNoMediaImageRemoval() {
+		// Create foo1.jpg in root and foo2.jpg in child directory
+		$view = new View('/' . $this->user->getUID() . '/files');
+		$view->file_put_contents("foo1.jpg", "content");
+		$view->mkdir('dir_nomedia');
+		$view->file_put_contents("dir_nomedia/foo2.jpg", "content");
+		// Create these two images in database by calling add missing images task
+		$this->config->setUserValue($this->user->getUID(), 'facerecognition', AddMissingImagesTask::FULL_IMAGE_SCAN_DONE_KEY, 'false');
+		$imageMapper = $this->container->query('OCA\FaceRecognition\Db\ImageMapper');
+		$addMissingImagesTask = new AddMissingImagesTask($this->config, $imageMapper);
+		$this->context->user = $this->user;
+		$generator = $addMissingImagesTask->execute($this->context);
+		foreach ($generator as $_) {
+		}
+		// TODO: add faces and person for those images, so we can exercise person
+		// invalidation and face removal when image is removed.
+
+		// We should find 2 images now - foo1.jpg, foo2.png
+		$this->assertEquals(2, count($imageMapper->findImagesWithoutFaces($this->user)));
+
+		// We should not delete anything this time
+		$this->doStaleImagesRemoval();
+		$this->assertEquals(0, $this->context->propertyBag['StaleImagesRemovalTask_staleRemovedImages']);
+
+		// Now add .nomedia file in subdirectory and one image (foo2.jpg) should be gone now
+		$view->file_put_contents("dir_nomedia/.nomedia", "content");
+		$this->doStaleImagesRemoval();
+		$this->assertEquals(1, $this->context->propertyBag['StaleImagesRemovalTask_staleRemovedImages']);
+		$this->assertEquals(1, count($imageMapper->findImagesWithoutFaces($this->user)));
+	}
+
+	/**
+	 * Helper method to set up and do scanning
+	 *
+	 * @param IUser|null $contextUser Optional user to scan for.
+	 * If not given, stale images for all users will be renived.
+	 */
+	private function doStaleImagesRemoval($contextUser = null) {
+		// Set config that stale image removal is needed
+		$this->config->setUserValue($this->user->getUID(), 'facerecognition', StaleImagesRemovalTask::STALE_IMAGES_REMOVAL_NEEDED_KEY, 'true');
+
+		$staleImagesRemovalTask = $this->createStaleImagesRemovalTask();
+		$this->assertNotEquals("", $staleImagesRemovalTask->description());
+
+		// Set user for which to do scanning, if any
+		$this->context->user = $contextUser;
+
+		// Since this task returns generator, iterate until it is done
+		$generator = $staleImagesRemovalTask->execute($this->context);
+		foreach ($generator as $_) {
+		}
+
+		$this->assertEquals(true, $generator->getReturn());
+	}
+
+	private function createStaleImagesRemovalTask() {
+		$imageMapper = $this->container->query('OCA\FaceRecognition\Db\ImageMapper');
+		$faceMapper = $this->container->query('OCA\FaceRecognition\Db\FaceMapper');
+		$personMapper = $this->container->query('OCA\FaceRecognition\Db\PersonMapper');
+		return new StaleImagesRemovalTask($this->config, $imageMapper, $faceMapper, $personMapper);
+	}
+}


### PR DESCRIPTION
Adds new task to remove images that either:
* exist in database, but do not exist on disk (this can happen because of bugs in Watcher, in testing, in manual fiddling to filesystem...)
* are under .nomedia because user added that file to it

This also fixes some small issues found along the way.

I learned (hard way:smiley:) that SQLite cannot have table aliases in UPDATE clauses (https://travis-ci.org/matiasdelellis/facerecognition/jobs/473327871). Change in PersonMapper.php is because of that:)

I think this is all from me for this year;) Let's release something next year!:)