### PR TITLE
Fixing wrong clustering

### DIFF
--- a/lib/BackgroundJob/Tasks/CreateClustersTask.php
+++ b/lib/BackgroundJob/Tasks/CreateClustersTask.php
@@ -147,7 +147,7 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 
 			if ($haveStalePersons === false && $haveNewFaces === false) {
 				// If there is no invalid persons, and there is no recent new faces, no need to recreate cluster
-				$this->logInfo('Clusters already exist, calculated there is no need to recreate them');
+				$this->logInfo('Clusters already exist, estimated there is no need to recreate them');
 				return;
 			}
 		} else {


### PR DESCRIPTION
With lot of faces/persons, this bug manifests as some faces have person=null (do not have cluster) after clustering. When this happens, create cluster is happening again and again, never stopping. 

OK, this one is hard to explain, but I will try. Face can "jump" from one cluster to another cluster. During DB merging, we are setting person=null when we see that face is not in one cluster and afterwards we set it to correct person when other cluster is processed. However, sometimes setting person=null can happen *after* setting it to new cluster, so effectively we leave face without cluster (person=null). This is because, when we want to set person=null, we need first to see if it happens in other clusters.

Also changed here is split between iteration of "add/modify" to separate "add" and "modify" clusters operations.

Tested locally and with 12000 of my faces in DB, seems there is no regression:)