### PR TITLE
Add command for reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,29 +62,32 @@ make
 
 ## Commands
 
-There is a single command with which the administrator must work.
-This process can took a lot of CPU and Memory therefore it is recommended to
-run it for a reasonable amount of time. Perhaps a scheduled task with cron to
-be executed once a day.
+### Face analysis
 
-### face:background_job [-u user-id] [-t timeout]
+`occ face:background_job [-u user-id] [-t timeout]`
 
 This command will do all the work. It is responsible for searching the images,
-analyzing them and clustering them in groups of similar people.
+analyzing them and clustering faces found in them in groups of similar people.
 
-If `user-id` is supplied just loop over the files for that user.
+Beware that this command can take a lot of CPU and memory! Before you put it to
+cron job, it is advised to try it out manually first, just to be sure you have
+all requirements and you have enough resources on your machine.
+
+Command is designed to be run continuously, so you will want to schedule it with cron to be executed every once in a while, together with a specified timeout. It can be run every 15 minutes with timeout of `-t 900` (so, it will stop itself automatically after 15 minutes and cron will start it again), or
+once a day with timeout of 2 hours, like `-t 7200`.
+
+If `user-id` is supplied, it will just loop over files of a given user.
 
 If `timeout` is supplied it will stop after the indicated seconds, and continue
 in the next execution. Use this value in conjunction with the times of the
 scheduled task to distribute the system load during the day.
 
 ### Resetting faces
-Run following SQL statements on your Nextcloud DB:
-```
-TRUNCATE oc_face_recognition_faces;
-TRUNCATE oc_face_recognition_persons;
-TRUNCATE oc_face_recognition_images;
-DELETE FROM oc_preferences WHERE configkey="full_image_scan_done";
-```
 
-Then run `face:background_job` again
+`occ face:reset_all [-u user-id]`
+
+This command will completely wipe out all images, faces and cluster of persons.
+It is ideal if you want to start from scratch for any reason. Beware that all
+images will have to be analyzed again!
+
+If `user-id` is supplied, it will just loop over files of a given user.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -37,6 +37,7 @@
 	</repair-steps>
 	<commands>
 		<command>OCA\FaceRecognition\Command\BackgroundCommand</command>
+		<command>OCA\FaceRecognition\Command\ResetAllCommand</command>
 	</commands>
 	<settings>
 		<admin>OCA\FaceRecognition\Settings\Admin</admin>

--- a/lib/Command/ResetAllCommand.php
+++ b/lib/Command/ResetAllCommand.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017, Matias De lellis <mati86dl@gmail.com>
+ * @copyright Copyright (c) 2018, Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @author Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\FaceRecognition\Command;
+
+use OCP\IUserManager;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use OCA\FaceRecognition\FaceManagementService;
+
+class ResetAllCommand extends Command {
+
+	/** @var FaceManagementService */
+	protected $faceManagementService;
+
+	/** @var IUserManager */
+	protected $userManager;
+
+	/**
+	 * @param FaceManagementService $faceManagementService
+	 * @param IUserManager $userManager
+	 */
+	public function __construct(FaceManagementService $faceManagementService,
+	                            IUserManager          $userManager) {
+		parent::__construct();
+
+		$this->faceManagementService = $faceManagementService;
+		$this->userManager = $userManager;
+	}
+
+	protected function configure() {
+		$this
+			->setName('face:reset_all')
+			->setDescription(
+				'Resets and deletes everything. Good for starting over. ' .
+				'BEWARE: Next runs of face:background_job will re-analyze all images.')
+			->addOption(
+				'user_id',
+				'u',
+				InputOption::VALUE_REQUIRED,
+				'Resets data for a given user only. If not given, resets everything for all users.',
+				null
+			);
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		// Extract user, if any
+		//
+		$userId = $input->getOption('user_id');
+		$user = null;
+
+		if (!is_null($userId)) {
+			$user = $this->userManager->get($userId);
+			if ($user === null) {
+				throw new \InvalidArgumentException("User with id <$userId> in unknown.");
+			}
+		}
+
+		// Main thing
+		//
+		$this->faceManagementService->resetAll($user);
+		$output->writeln('Reset successfully done');
+
+		return 0;
+	}
+}

--- a/lib/Db/Face.php
+++ b/lib/Db/Face.php
@@ -35,6 +35,12 @@ use OCP\AppFramework\Db\Entity;
  * @method int getRight()
  * @method int getTop()
  * @method int getBottom()
+ * @method void setImage(int $image)
+ * @method void setPerson(int $person)
+ * @method void setLeft(int $left)
+ * @method void setRight(int $right)
+ * @method void setTop(int $top)
+ * @method void setBottom(int $bottom)
  */
 class Face extends Entity implements JsonSerializable {
 
@@ -103,14 +109,14 @@ class Face extends Entity implements JsonSerializable {
 	 */
 	public static function fromModel(int $image, array $faceFromModel): Face {
 		$face = new Face();
-		$face->image = $image;
-		$face->person = null;
-		$face->left = max($faceFromModel["left"], 0);
-		$face->right = $faceFromModel["right"];
-		$face->top = max($faceFromModel["top"], 0);
-		$face->bottom = $faceFromModel["bottom"];
-		$face->descriptor = array();
-		$face->creationTime = new \DateTime();
+		$face->setImage($image);
+		$face->setPerson(null);
+		$face->setLeft(max($faceFromModel["left"], 0));
+		$face->setRight($faceFromModel["right"]);
+		$face->setTop(max($faceFromModel["top"], 0));
+		$face->setBottom($faceFromModel["bottom"]);
+		$face->setDescriptor("[]");
+		$face->setCreationTime(new \DateTime());
 		return $face;
 	}
 
@@ -158,11 +164,27 @@ class Face extends Entity implements JsonSerializable {
 		];
 	}
 
+	public function getDescriptor(): string {
+		return json_encode($this->descriptor);
+	}
+
 	public function setDescriptor($descriptor) {
 		$this->descriptor = json_decode($descriptor);
+		$this->markFieldUpdated('descriptor');
+	}
+
+	public function getCreationTime(): string {
+		// Deck app have special handling for MySQL here:
+		// https://github.com/nextcloud/deck/blob/139b38ca1df0ff17792eb218cc8ba7e3b04b4e51/lib/Db/Card.php#L84
+		return $this->creationTime->format('c');
 	}
 
 	public function setCreationTime($creationTime) {
-		$this->creationTime = new \DateTime($creationTime);
+		if (is_a($creationTime, 'DateTime')) {
+			$this->creationTime = $creationTime;
+		} else {
+			$this->creationTime = new \DateTime($creationTime);
+		}
+		$this->markFieldUpdated('creationTime');
 	}
 }

--- a/lib/Db/FaceMapper.php
+++ b/lib/Db/FaceMapper.php
@@ -1,6 +1,8 @@
 <?php
 namespace OCA\FaceRecognition\Db;
 
+use OC\DB\QueryBuilder\Literal;
+
 use OCP\IDBConnection;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -149,4 +151,22 @@ class FaceMapper extends QBMapper {
 			->execute();
 	}
 
+	/**
+	 * Deletes all faces from that user.
+	 *
+	 * @param string $userId User to drop faces from table.
+	 */
+	public function deleteUserFaces(string $userId) {
+		$sub = $this->db->getQueryBuilder();
+		$sub->select(new Literal('1'));
+		$sub->from("face_recognition_images", "i")
+			->where($sub->expr()->eq('i.id', '*PREFIX*' . $this->getTableName() .'.image'))
+			->andWhere($sub->expr()->eq('i.user', $sub->createParameter('user')));
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where('EXISTS (' . $sub->getSQL() . ')')
+			->setParameter('user', $userId)
+			->execute();
+	}
 }

--- a/lib/Db/ImageMapper.php
+++ b/lib/Db/ImageMapper.php
@@ -272,4 +272,16 @@ class ImageMapper extends QBMapper {
 			->andWhere($qb->expr()->eq('model', $qb->createNamedParameter($image->getModel())))
 			->execute();
 	}
+
+	/**
+	 * Deletes all images from that user.
+	 *
+	 * @param string $userId User to drop images from table.
+	 */
+	public function deleteUserImages(string $userId) {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('user', $qb->createNamedParameter($userId)))
+			->execute();
+	}
 }

--- a/lib/Db/Person.php
+++ b/lib/Db/Person.php
@@ -39,7 +39,7 @@ class Person extends Entity implements JsonSerializable {
 	 *
 	 * @var string
 	 * */
-	protected $user_id;
+	protected $user;
 
 	/**
 	 * Name for this person/cluster. Must exists, even if linked user is set.
@@ -53,14 +53,14 @@ class Person extends Entity implements JsonSerializable {
 	 *
 	 * @var bool
 	 */
-	protected $is_valid;
+	protected $isValid;
 
 	/**
 	 * Last timestamp when this person/cluster was created, or when it was refreshed
 	 *
 	 * @var timestamp|null
 	 */
-	protected $last_generation_time;
+	protected $lastGenerationTime;
 
 	/**
 	 * Foreign key to other user that this person belongs to (if it is on same Nextcloud instance).
@@ -68,16 +68,16 @@ class Person extends Entity implements JsonSerializable {
 	 *
 	 * @var string|null
 	*/
-	protected $linked_user_id;
+	protected $linkedUser;
 
 	public function jsonSerialize() {
 		return [
 			'id' => $this->id,
-			'user' => $this->user_id,
+			'user' => $this->user,
 			'name' => $this->name,
-			'is_valid' => $this->is_valid,
-			'last_generation_time' => $this->last_generation_time,
-			'linked_user' => $this->linked_user_id
+			'is_valid' => $this->isValid,
+			'last_generation_time' => $this->lastGenerationTime,
+			'linked_user' => $this->linkedUser
 		];
 	}
 }

--- a/lib/Db/PersonMapper.php
+++ b/lib/Db/PersonMapper.php
@@ -250,6 +250,18 @@ class PersonMapper extends QBMapper {
 	}
 
 	/**
+	 * Deletes all persons from that user.
+	 *
+	 * @param string $userId User to drop persons from a table.
+	 */
+	public function deleteUserPersons(string $userId) {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('user', $qb->createNamedParameter($userId)))
+			->execute();
+	}
+
+	/**
 	 * Checks if face with a given ID is in any cluster.
 	 *
 	 * @param int $faceId ID of the face to check

--- a/lib/FaceManagementService.php
+++ b/lib/FaceManagementService.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017, Matias De lellis <mati86dl@gmail.com>
+ * @copyright Copyright (c) 2018, Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @author Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\FaceRecognition;
+
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\IUserManager;
+
+use OCA\FaceRecognition\Db\FaceMapper;
+use OCA\FaceRecognition\Db\ImageMapper;
+use OCA\FaceRecognition\Db\PersonMapper;
+
+use OCA\FaceRecognition\BackgroundJob\Tasks\AddMissingImagesTask;
+
+/**
+ * Background service. Both command and cron job are calling this service for long-running background operations.
+ * Background processing for face recognition is comprised of several steps, called tasks. Each task is independent,
+ * idempotent, DI-aware logic unit that yields. Since tasks are non-preemptive, they should yield from time to time, so we son't end up
+ * working for more than given timeout.
+ *
+ * Tasks can be seen as normal sequential functions, but they are easier to work with,
+ * reason about them and test them independently. Other than that, they are really glorified functions.
+ */
+class FaceManagementService {
+
+	/** @var IConfig */
+	private $config;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var FaceMapper */
+	private $faceMapper;
+
+	/** @var ImageMapper */
+	private $imageMapper;
+
+	/** @var PersonMapper */
+	private $personMapper;
+
+	public function __construct(IConfig $config, IUserManager $userManager,
+			FaceMapper $faceMapper, ImageMapper $imageMapper, PersonMapper $personMapper) {
+		$this->config = $config;
+		$this->userManager = $userManager;
+		$this->faceMapper = $faceMapper;
+		$this->imageMapper = $imageMapper;
+		$this->personMapper = $personMapper;
+	}
+
+	/**
+	 * Deletes all faces, images and persons found. IF no user is given, resetting is executed for all users.
+	 *
+	 * @param IUser|null $user Optional user to execute resetting for
+	 */
+	public function resetAll(IUser $user = null) {
+		$eligable_users = array();
+		if (is_null($user)) {
+			$this->userManager->callForAllUsers(function (IUser $user) use (&$eligable_users) {
+				$eligable_users[] = $user->getUID();
+			});
+		} else {
+			$eligable_users[] = $user->getUID();
+		}
+
+		foreach($eligable_users as $user) {
+			$this->resetAllForUser($user);
+		}
+	}
+
+	/**
+	 * Deletes all faces, images and persons found for a given user.
+	 *
+	 * @param string $user ID of user to execute resetting for
+	 */
+	public function resetAllForUser(string $userId) {
+		$this->faceMapper->deleteUserFaces($userId);
+		$this->personMapper->deleteUserPersons($userId);
+		$this->imageMapper->deleteUserImages($userId);
+		$this->config->deleteUserValue($userId, 'facerecognition', AddMissingImagesTask::FULL_IMAGE_SCAN_DONE_KEY);
+	}
+}

--- a/tests/integration/ResetAllTest.php
+++ b/tests/integration/ResetAllTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017, Matias De lellis <mati86dl@gmail.com>
+ * @copyright Copyright (c) 2018, Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @author Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\FaceRecognition\Tests\Integration;
+
+use OC;
+use OC\Files\View;
+
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\AppFramework\App;
+use OCP\AppFramework\IAppContainer;
+
+use OCA\FaceRecognition\FaceManagementService;
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionContext;
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionLogger;
+use OCA\FaceRecognition\BackgroundJob\Tasks\AddMissingImagesTask;
+use OCA\FaceRecognition\Db\Face;
+use OCA\FaceRecognition\Db\Image;
+use OCA\FaceRecognition\Db\Person;
+use OCA\FaceRecognition\Migration\AddDefaultFaceModel;
+
+use Test\TestCase;
+
+class ResetAllTest extends TestCase {
+	/** @var IAppContainer */
+	private $container;
+
+	/** @var FaceRecognitionContext Context */
+	private $context;
+
+	/** @var IUser User */
+	private $user;
+
+	/** @var IConfig Config */
+	private $config;
+
+	public function setUp() {
+		parent::setUp();
+		// Better safe than sorry. Warn user that database will be changed in chaotic manner:)
+		if (false === getenv('TRAVIS')) {
+			$this->fail("This test touches database. Add \"TRAVIS\" env variable if you want to run these test on your local instance.");
+		}
+
+		// Create user on which we will upload images and do testing
+		$userManager = OC::$server->getUserManager();
+		$username = 'testuser' . rand(0, PHP_INT_MAX);
+		$this->user = $userManager->createUser($username, 'password');
+		$this->loginAsUser($username);
+		// Get container to get classes using DI
+		$app = new App('facerecognition');
+		$this->container = $app->getContainer();
+
+		// Insantiate our context, that all tasks need
+		$appManager = $this->container->query('OCP\App\IAppManager');
+		$userManager = $this->container->query('OCP\IUserManager');
+		$rootFolder = $this->container->query('OCP\Files\IRootFolder');
+		$this->config = $this->container->query('OCP\IConfig');
+		$logger = $this->container->query('OCP\ILogger');
+		$this->context = new FaceRecognitionContext($appManager, $userManager, $rootFolder, $this->config);
+		$this->context->logger = new FaceRecognitionLogger($logger);
+	}
+
+	public function tearDown() {
+		$this->user->delete();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that AddMissingImagesTask is updating app config that it finished full scan.
+	 * Note that, in this test, we cannot check number of newly found images,
+	 * as this instance might be in use and can lead to wrong results
+	 */
+	public function testResetAll() {
+		// Add one image to DB
+		$imageMapper = $this->container->query('OCA\FaceRecognition\Db\ImageMapper');
+		$image = new Image();
+		$image->setUser($this->user->getUid());
+		$image->setFile(1);
+		$image->setModel(AddDefaultFaceModel::DEFAULT_FACE_MODEL_ID);
+		$imageMapper->insert($image);
+		$imageCount = $imageMapper->countUserImages($this->user->getUID(), AddDefaultFaceModel::DEFAULT_FACE_MODEL_ID);
+		$this->assertEquals(1, $imageCount);
+
+		// Add one face to DB
+		$faceMapper = $this->container->query('OCA\FaceRecognition\Db\FaceMapper');
+		$face = Face::fromModel($image->getId(), array("left"=>0, "right"=>100, "top"=>0, "bottom"=>100));
+		$faceMapper->insert($face);
+		$faceCount = $faceMapper->countFaces($this->user->getUID(), AddDefaultFaceModel::DEFAULT_FACE_MODEL_ID);
+		$this->assertEquals(1, $faceCount);
+
+		// Add one person to DB
+		$personMapper = $this->container->query('OCA\FaceRecognition\Db\PersonMapper');
+		$person = new Person();
+		$person->setUser($this->user->getUID());
+		$person->setName('foo');
+		$person->setIsValid(true);
+		$personMapper->insert($person);
+		$personCount = $personMapper->countPersons($this->user->getUID());
+		$this->assertEquals(1, $personCount);
+
+		// Execute reset all
+		$userManager = $this->container->query('OCP\IUserManager');
+		$faceMgmtService = new FaceManagementService($this->config, $userManager, $faceMapper, $imageMapper, $personMapper);
+		$faceMgmtService->resetAllForUser($this->user->getUID());
+
+		// Check that everything is gone
+		$imageCount = $imageMapper->countUserImages($this->user->getUID(), AddDefaultFaceModel::DEFAULT_FACE_MODEL_ID);
+		$this->assertEquals(0, $imageCount);
+		$faceCount = $faceMapper->countFaces($this->user->getUID(), AddDefaultFaceModel::DEFAULT_FACE_MODEL_ID);
+		$this->assertEquals(0, $faceCount);
+		$personCount = $personMapper->countPersons($this->user->getUID());
+		$this->assertEquals(0, $personCount);
+	}
+}


### PR DESCRIPTION
This PR adds new service (`FaceManagementService`) that gather ("business") logic for resetting images/faces/persons in one single place. I needed it as part of #32, and @matiasdelellis needed it as part of PR #84, and @SlavikCA also changed README to include SQL to reset stuff, so yeah - this was needed. Maybe @matiasdelellis have some other suggestion where logic from this service could live (maybe in `SettingsController`).

To be able to test this resetting, I also created new command, and also added additional basic test to try this all out end-to-end.

Only bigger issue I had was with table aliasing when deleting with subquery (in `FaceMapper.php`). PostgreSQL has table aliasing in delete, MySQL and SQLite not. In the end, I solved it by removing alias in table name and using table name in subquery (but I had to hardcode `*PREFIX*` literal). In other words, I could not use `DELETE FROM faces f WHERE EXISTS (SELECT 1 FROM images i WHERE i.id=f.image)`, but I had to use `DELETE FROM faces WHERE EXISTS (SELECT 1 FROM images i WHERE i.id=faces.image)`.