### PR TITLE
Fix for non-existing image

### DIFF
--- a/lib/BackgroundJob/Tasks/ImageProcessingTask.php
+++ b/lib/BackgroundJob/Tasks/ImageProcessingTask.php
@@ -162,9 +162,11 @@ class ImageProcessingTask extends FaceRecognitionBackgroundTask {
 					$this->populateDescriptors($fld, $fr, $imageProcessingContext);
 				}
 
-				$endMillis = round(microtime(true) * 1000);
-				$duration = max($endMillis - $startMillis, 0);
-				$this->imageMapper->imageProcessed($image, $imageProcessingContext->getFaces(), $duration);
+				if ($imageProcessingContext !== null) {
+					$endMillis = round(microtime(true) * 1000);
+					$duration = max($endMillis - $startMillis, 0);
+					$this->imageMapper->imageProcessed($image, $imageProcessingContext->getFaces(), $duration);
+				}
 			} catch (\Exception $e) {
 				$this->imageMapper->imageProcessed($image, array(), 0, $e);
 			} finally {

--- a/lib/BackgroundJob/Tasks/ImageProcessingTask.php
+++ b/lib/BackgroundJob/Tasks/ImageProcessingTask.php
@@ -156,17 +156,20 @@ class ImageProcessingTask extends FaceRecognitionBackgroundTask {
 
 			$imageProcessingContext = null;
 			$startMillis = round(microtime(true) * 1000);
+
 			try {
 				$imageProcessingContext = $this->findFaces($cfd, $dataDir, $image);
 				if (($imageProcessingContext !== null) && ($imageProcessingContext->getSkipDetection() === false)) {
 					$this->populateDescriptors($fld, $fr, $imageProcessingContext);
 				}
 
-				if ($imageProcessingContext !== null) {
-					$endMillis = round(microtime(true) * 1000);
-					$duration = max($endMillis - $startMillis, 0);
-					$this->imageMapper->imageProcessed($image, $imageProcessingContext->getFaces(), $duration);
+				if ($imageProcessingContext === null) {
+					continue;
 				}
+
+				$endMillis = round(microtime(true) * 1000);
+				$duration = max($endMillis - $startMillis, 0);
+				$this->imageMapper->imageProcessed($image, $imageProcessingContext->getFaces(), $duration);
 			} catch (\Exception $e) {
 				$this->imageMapper->imageProcessed($image, array(), 0, $e);
 			} finally {


### PR DESCRIPTION
If image doesn't exist on disk, but do exist in Nextcloud filecache,
we don't see it, and we don't want to add it to our database
(by-design).
So, we signal that processing context is null, but code had bug
(regression actually) where it did not handle null case. This fixes it.