### PR TITLE
Adding support to remove data from deleted users, fixes #32

### DIFF
--- a/lib/Watcher.php
+++ b/lib/Watcher.php
@@ -82,15 +82,14 @@ class Watcher {
 	 * @param PersonMapper $personMapper
 	 * @param FaceManagementService $faceManagementService
 	 */
-	public function __construct(
-								IConfig               $config,
-								ILogger               $logger,
-								IDBConnection         $connection,
-								IUserManager          $userManager,
-								FaceMapper            $faceMapper,
-								ImageMapper           $imageMapper,
-								PersonMapper          $personMapper,
-								FaceManagementService $faceManagementService)
+	public function __construct(IConfig               $config,
+	                            ILogger               $logger,
+	                            IDBConnection         $connection,
+	                            IUserManager          $userManager,
+	                            FaceMapper            $faceMapper,
+	                            ImageMapper           $imageMapper,
+	                            PersonMapper          $personMapper,
+	                            FaceManagementService $faceManagementService)
 	{
 		$this->config = $config;
 		$this->logger = $logger;


### PR DESCRIPTION
If user is deleted from Nextcloud, all files from that users are also deleted. However, we don't have callback for that, and we end up with bunch of images/faces/persons in database which do not exist anymore, either in filecache or physically, on disk. Since those stuff can pile up, best is to clean them from time to time, and we use another task for that.

Tests also added.