### PR TITLE
Inserting faces manually (going around QBMapper)

### DIFF
--- a/lib/Db/Face.php
+++ b/lib/Db/Face.php
@@ -173,12 +173,6 @@ class Face extends Entity implements JsonSerializable {
 		$this->markFieldUpdated('descriptor');
 	}
 
-	public function getCreationTime(): string {
-		// Deck app have special handling for MySQL here:
-		// https://github.com/nextcloud/deck/blob/139b38ca1df0ff17792eb218cc8ba7e3b04b4e51/lib/Db/Card.php#L84
-		return $this->creationTime->format('c');
-	}
-
 	public function setCreationTime($creationTime) {
 		if (is_a($creationTime, 'DateTime')) {
 			$this->creationTime = $creationTime;

--- a/lib/Db/FaceMapper.php
+++ b/lib/Db/FaceMapper.php
@@ -169,4 +169,33 @@ class FaceMapper extends QBMapper {
 			->setParameter('user', $userId)
 			->execute();
 	}
+
+	/**
+	 * Insert one face to database.
+	 * Note: only reason we are not using (idiomatic) QBMapper method is
+	 * because "QueryBuilder::PARAM_DATE" cannot be set there
+	 *
+	 * @param Face $face Face to insert
+	 * @param IDBConnection $db Existing connection, if we need to reuse it. Null if we commit immediatelly.
+	 */
+	public function insertFace(Face $face, IDBConnection $db = null) {
+		if ($db !== null) {
+			$qb = $db->getQueryBuilder();
+		} else {
+			$qb = $this->db->getQueryBuilder();
+		}
+
+		$qb->insert($this->getTableName())
+			->values([
+				'image' => $qb->createNamedParameter($face->image),
+				'person' => $qb->createNamedParameter($face->person),
+				'left' => $qb->createNamedParameter($face->left),
+				'right' => $qb->createNamedParameter($face->right),
+				'top' => $qb->createNamedParameter($face->top),
+				'bottom' => $qb->createNamedParameter($face->bottom),
+				'descriptor' => $qb->createNamedParameter(json_encode($face->descriptor)),
+				'creation_time' => $qb->createNamedParameter($face->creationTime, IQueryBuilder::PARAM_DATE),
+			])
+			->execute();
+	}
 }

--- a/tests/integration/ResetAllTest.php
+++ b/tests/integration/ResetAllTest.php
@@ -105,7 +105,7 @@ class ResetAllTest extends TestCase {
 		// Add one face to DB
 		$faceMapper = $this->container->query('OCA\FaceRecognition\Db\FaceMapper');
 		$face = Face::fromModel($image->getId(), array("left"=>0, "right"=>100, "top"=>0, "bottom"=>100));
-		$faceMapper->insert($face);
+		$faceMapper->insertFace($face);
 		$faceCount = $faceMapper->countFaces($this->user->getUID(), AddDefaultFaceModel::DEFAULT_FACE_MODEL_ID);
 		$this->assertEquals(1, $faceCount);
 


### PR DESCRIPTION
I filed issue here: https://github.com/nextcloud/server/issues/14611

This related to previous discussion here:
https://github.com/matiasdelellis/facerecognition/pull/124/files/66d662aa8489e4217a9dcffe33354898a09e35fa#diff-7c0dc1009c412be1b3b12cc76826d3af

So, I finally found where is issue. It is because QBMapper cannot handle `\DateTime` and nobody seems to care (because they wither don't use timestamp, or don't use QBMapper). Deck is the only one and is having this hack. Until it QBMapper is improved, we can either:
* do what Deck app did - and which I did in this push and we said it is ugly
* manually insert faces, as in this push request

Personally, I like this approach more (yes, it is more boilerplate code, but even that is better than hacks about knowing what is your database type)