### PR TITLE
Adding common functionality under one integration test case

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,12 +4,12 @@
             <directory>./tests/unit</directory>
         </testsuite>
         <testsuite name="integration">
-            <directory>./tests/integration</directory>
+            <directory>./tests/Integration</directory>
         </testsuite>
     </testsuites>
     <filter>
         <whitelist>
             <directory suffix=".php">lib</directory>
         </whitelist>
-</filter>
+    </filter>
 </phpunit>

--- a/tests/Integration/AddMissingImagesTaskTest.php
+++ b/tests/Integration/AddMissingImagesTaskTest.php
@@ -35,55 +35,7 @@ use OCA\FaceRecognition\BackgroundJob\FaceRecognitionContext;
 use OCA\FaceRecognition\BackgroundJob\FaceRecognitionLogger;
 use OCA\FaceRecognition\BackgroundJob\Tasks\AddMissingImagesTask;
 
-use Test\TestCase;
-
-class AddMissingImagesTaskTest extends TestCase {
-	/** @var IAppContainer */
-	private $container;
-
-	/** @var FaceRecognitionContext Context */
-	private $context;
-
-	/** @var IUser User */
-	private $user;
-
-	/** @var IConfig Config */
-	private $config;
-
-	public function setUp() {
-		parent::setUp();
-		// Better safe than sorry. Warn user that database will be changed in chaotic manner:)
-		if (false === getenv('TRAVIS')) {
-			$this->fail("This test touches database. Add \"TRAVIS\" env variable if you want to run these test on your local instance.");
-		}
-
-		// Create user on which we will upload images and do testing
-		$userManager = OC::$server->getUserManager();
-		$username = 'testuser' . rand(0, PHP_INT_MAX);
-		$this->user = $userManager->createUser($username, 'password');
-		$this->loginAsUser($username);
-		// Get container to get classes using DI
-		$app = new App('facerecognition');
-		$this->container = $app->getContainer();
-
-		// Insantiate our context, that all tasks need
-		$appManager = $this->container->query('OCP\App\IAppManager');
-		$userManager = $this->container->query('OCP\IUserManager');
-		$rootFolder = $this->container->query('OCP\Files\IRootFolder');
-		$this->config = $this->container->query('OCP\IConfig');
-		$logger = $this->container->query('OCP\ILogger');
-		$this->context = new FaceRecognitionContext($appManager, $userManager, $rootFolder, $this->config);
-		$this->context->logger = new FaceRecognitionLogger($logger);
-	}
-
-	public function tearDown() {
-		$faceMgmtService = $this->container->query('OCA\FaceRecognition\FaceManagementService');
-		$faceMgmtService->resetAllForUser($this->user->getUID());
-
-		$this->user->delete();
-
-		parent::tearDown();
-	}
+class AddMissingImagesTaskTest extends IntegrationTestCase {
 
 	/**
 	 * Test that AddMissingImagesTask is updating app config that it finished full scan.

--- a/tests/Integration/AppTest.php
+++ b/tests/Integration/AppTest.php
@@ -26,11 +26,7 @@ namespace OCA\FaceRecognition\Tests\Integration;
 use OCP\AppFramework\App;
 use OCP\AppFramework\IAppContainer;
 
-use Test\TestCase;
-
-class AppTest extends TestCase {
-	/** @var IAppContainer */
-	private $container;
+class AppTest extends IntegrationTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/Integration/CreateClustersTaskTest.php
+++ b/tests/Integration/CreateClustersTaskTest.php
@@ -38,53 +38,7 @@ use OCA\FaceRecognition\Migration\AddDefaultFaceModel;
 
 use Test\TestCase;
 
-class CreateClustersTaskTest extends TestCase {
-	/** @var IAppContainer */
-	private $container;
-
-	/** @var FaceRecognitionContext Context */
-	private $context;
-
-	/** @var IUser User */
-	private $user;
-
-	/** @var IConfig Config */
-	private $config;
-
-	public function setUp() {
-		parent::setUp();
-		// Better safe than sorry. Warn user that database will be changed in chaotic manner:)
-		if (false === getenv('TRAVIS')) {
-			$this->fail("This test touches database. Add \"TRAVIS\" env variable if you want to run these test on your local instance.");
-		}
-
-		// Create user on which we will upload images and do testing
-		$userManager = OC::$server->getUserManager();
-		$username = 'testuser' . rand(0, PHP_INT_MAX);
-		$this->user = $userManager->createUser($username, 'password');
-		$this->loginAsUser($username);
-		// Get container to get classes using DI
-		$app = new App('facerecognition');
-		$this->container = $app->getContainer();
-
-		// Insantiate our context, that all tasks need
-		$appManager = $this->container->query('OCP\App\IAppManager');
-		$userManager = $this->container->query('OCP\IUserManager');
-		$rootFolder = $this->container->query('OCP\Files\IRootFolder');
-		$this->config = $this->container->query('OCP\IConfig');
-		$logger = $this->container->query('OCP\ILogger');
-		$this->context = new FaceRecognitionContext($appManager, $userManager, $rootFolder, $this->config);
-		$this->context->logger = new FaceRecognitionLogger($logger);
-	}
-
-	public function tearDown() {
-		$faceMgmtService = $this->container->query('OCA\FaceRecognition\FaceManagementService');
-		$faceMgmtService->resetAllForUser($this->user->getUID());
-
-		$this->user->delete();
-
-		parent::tearDown();
-	}
+class CreateClustersTaskTest extends IntegrationTestCase {
 
 	/**
 	 * Test that one face that was not in any cluster will be assigned new person

--- a/tests/Integration/ImageProcessingTaskTest.php
+++ b/tests/Integration/ImageProcessingTaskTest.php
@@ -40,43 +40,10 @@ use OCA\FaceRecognition\Migration\AddDefaultFaceModel;
 
 use Test\TestCase;
 
-class ImageProcessingTaskTest extends TestCase {
-	/** @var IAppContainer */
-	private $container;
-
-	/** @var FaceRecognitionContext Context */
-	private $context;
-
-	/** @var IUser User */
-	private $user;
-
-	/** @var IConfig Config */
-	private $config;
+class ImageProcessingTaskTest extends IntegrationTestCase {
 
 	public function setUp() {
 		parent::setUp();
-		// Better safe than sorry. Warn user that database will be changed in chaotic manner:)
-		if (false === getenv('TRAVIS')) {
-			$this->fail("This test touches database. Add \"TRAVIS\" env variable if you want to run these test on your local instance.");
-		}
-
-		// Create user on which we will upload images and do testing
-		$userManager = OC::$server->getUserManager();
-		$username = 'testuser' . rand(0, PHP_INT_MAX);
-		$this->user = $userManager->createUser($username, 'password');
-		$this->loginAsUser($username);
-		// Get container to get classes using DI
-		$app = new App('facerecognition');
-		$this->container = $app->getContainer();
-
-		// Instantiate our context, that all tasks need
-		$appManager = $this->container->query('OCP\App\IAppManager');
-		$userManager = $this->container->query('OCP\IUserManager');
-		$rootFolder = $this->container->query('OCP\Files\IRootFolder');
-		$this->config = $this->container->query('OCP\IConfig');
-		$logger = $this->container->query('OCP\ILogger');
-		$this->context = new FaceRecognitionContext($appManager, $userManager, $rootFolder, $this->config);
-		$this->context->logger = new FaceRecognitionLogger($logger);
 
 		// Since test is changing this values, try to preserve old values (this is best effort)
 		$this->originalMinImageSize = intval($this->config->getAppValue('facerecognition', 'min_image_size', '512'));
@@ -89,10 +56,6 @@ class ImageProcessingTaskTest extends TestCase {
 		$this->config->setAppValue('facerecognition', 'min_image_size', $this->originalMinImageSize);
 		$this->config->setAppValue('facerecognition', 'max_image_area', $this->originalMaxImageArea);
 
-		$faceMgmtService = $this->container->query('OCA\FaceRecognition\FaceManagementService');
-		$faceMgmtService->resetAllForUser($this->user->getUID());
-
-		$this->user->delete();
 		parent::tearDown();
 	}
 

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017, Matias De lellis <mati86dl@gmail.com>
+ * @copyright Copyright (c) 2018, Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @author Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\FaceRecognition\Tests\Integration;
+
+use OC;
+use OC\Files\View;
+
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\AppFramework\App;
+use OCP\AppFramework\IAppContainer;
+
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionContext;
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionLogger;
+use OCA\FaceRecognition\BackgroundJob\Tasks\AddMissingImagesTask;
+
+use Test\TestCase;
+
+/**
+ * Main class that all integration tests should inherit from.
+ */
+abstract class IntegrationTestCase extends TestCase {
+	/** @var IAppContainer */
+	protected $container;
+
+	/** @var FaceRecognitionContext Context */
+	protected $context;
+
+	/** @var IUser User */
+	protected $user;
+
+	/** @var IConfig Config */
+	protected $config;
+
+	public function setUp() {
+		parent::setUp();
+		// Better safe than sorry. Warn user that database will be changed in chaotic manner:)
+		if (false === getenv('TRAVIS')) {
+			$this->fail("This test touches database. Add \"TRAVIS\" env variable if you want to run these test on your local instance.");
+		}
+
+		// Create user on which we will upload images and do testing
+		$userManager = OC::$server->getUserManager();
+		$username = 'testuser' . rand(0, PHP_INT_MAX);
+		$this->user = $userManager->createUser($username, 'password');
+		$this->loginAsUser($username);
+		// Get container to get classes using DI
+		$app = new App('facerecognition');
+		$this->container = $app->getContainer();
+
+		// Insantiate our context, that all tasks need
+		$appManager = $this->container->query('OCP\App\IAppManager');
+		$userManager = $this->container->query('OCP\IUserManager');
+		$rootFolder = $this->container->query('OCP\Files\IRootFolder');
+		$this->config = $this->container->query('OCP\IConfig');
+		$logger = $this->container->query('OCP\ILogger');
+		$this->context = new FaceRecognitionContext($appManager, $userManager, $rootFolder, $this->config);
+		$this->context->logger = new FaceRecognitionLogger($logger);
+	}
+
+	public function tearDown() {
+		$faceMgmtService = $this->container->query('OCA\FaceRecognition\FaceManagementService');
+		$faceMgmtService->resetAllForUser($this->user->getUID());
+
+		$this->user->delete();
+
+		parent::tearDown();
+	}
+}

--- a/tests/Integration/MergeClusterToDatabaseTest.php
+++ b/tests/Integration/MergeClusterToDatabaseTest.php
@@ -40,53 +40,7 @@ use OCA\FaceRecognition\Migration\AddDefaultFaceModel;
 
 use Test\TestCase;
 
-class MergeClusterToDatabaseTest extends TestCase {
-	/** @var IAppContainer */
-	private $container;
-
-	/** @var FaceRecognitionContext Context */
-	private $context;
-
-	/** @var IUser User */
-	private $user;
-
-	/** @var IConfig Config */
-	private $config;
-
-	public function setUp() {
-		parent::setUp();
-		// Better safe than sorry. Warn user that database will be changed in chaotic manner:)
-		if (false === getenv('TRAVIS')) {
-			$this->fail("This test touches database. Add \"TRAVIS\" env variable if you want to run these test on your local instance.");
-		}
-
-		// Create user on which we will upload images and do testing
-		$userManager = OC::$server->getUserManager();
-		$username = 'testuser' . rand(0, PHP_INT_MAX);
-		$this->user = $userManager->createUser($username, 'password');
-		$this->loginAsUser($username);
-		// Get container to get classes using DI
-		$app = new App('facerecognition');
-		$this->container = $app->getContainer();
-
-		// Insantiate our context, that all tasks need
-		$appManager = $this->container->query('OCP\App\IAppManager');
-		$userManager = $this->container->query('OCP\IUserManager');
-		$rootFolder = $this->container->query('OCP\Files\IRootFolder');
-		$this->config = $this->container->query('OCP\IConfig');
-		$logger = $this->container->query('OCP\ILogger');
-		$this->context = new FaceRecognitionContext($appManager, $userManager, $rootFolder, $this->config);
-		$this->context->logger = new FaceRecognitionLogger($logger);
-	}
-
-	public function tearDown() {
-		$faceMgmtService = $this->container->query('OCA\FaceRecognition\FaceManagementService');
-		$faceMgmtService->resetAllForUser($this->user->getUID());
-
-		$this->user->delete();
-
-		parent::tearDown();
-	}
+class MergeClusterToDatabaseTest extends IntegrationTestCase {
 
 	public function testMergeEmptyClusterToDatabase() {
 		$personMapper = $this->container->query('OCA\FaceRecognition\Db\PersonMapper');

--- a/tests/Integration/ResetAllTest.php
+++ b/tests/Integration/ResetAllTest.php
@@ -42,49 +42,7 @@ use OCA\FaceRecognition\Migration\AddDefaultFaceModel;
 
 use Test\TestCase;
 
-class ResetAllTest extends TestCase {
-	/** @var IAppContainer */
-	private $container;
-
-	/** @var FaceRecognitionContext Context */
-	private $context;
-
-	/** @var IUser User */
-	private $user;
-
-	/** @var IConfig Config */
-	private $config;
-
-	public function setUp() {
-		parent::setUp();
-		// Better safe than sorry. Warn user that database will be changed in chaotic manner:)
-		if (false === getenv('TRAVIS')) {
-			$this->fail("This test touches database. Add \"TRAVIS\" env variable if you want to run these test on your local instance.");
-		}
-
-		// Create user on which we will upload images and do testing
-		$userManager = OC::$server->getUserManager();
-		$username = 'testuser' . rand(0, PHP_INT_MAX);
-		$this->user = $userManager->createUser($username, 'password');
-		$this->loginAsUser($username);
-		// Get container to get classes using DI
-		$app = new App('facerecognition');
-		$this->container = $app->getContainer();
-
-		// Insantiate our context, that all tasks need
-		$appManager = $this->container->query('OCP\App\IAppManager');
-		$userManager = $this->container->query('OCP\IUserManager');
-		$rootFolder = $this->container->query('OCP\Files\IRootFolder');
-		$this->config = $this->container->query('OCP\IConfig');
-		$logger = $this->container->query('OCP\ILogger');
-		$this->context = new FaceRecognitionContext($appManager, $userManager, $rootFolder, $this->config);
-		$this->context->logger = new FaceRecognitionLogger($logger);
-	}
-
-	public function tearDown() {
-		$this->user->delete();
-		parent::tearDown();
-	}
+class ResetAllTest extends IntegrationTestCase {
 
 	/**
 	 * Test that AddMissingImagesTask is updating app config that it finished full scan.

--- a/tests/Integration/StaleImagesRemovalTaskTest.php
+++ b/tests/Integration/StaleImagesRemovalTaskTest.php
@@ -40,52 +40,7 @@ use OCA\FaceRecognition\Migration\AddDefaultFaceModel;
 
 use Test\TestCase;
 
-class StaleImagesRemovalTaskTest extends TestCase {
-	/** @var IAppContainer */
-	private $container;
-
-	/** @var FaceRecognitionContext Context */
-	private $context;
-
-	/** @var IUser User */
-	private $user;
-
-	/** @var IConfig Config */
-	private $config;
-
-	public function setUp() {
-		parent::setUp();
-		// Better safe than sorry. Warn user that database will be changed in chaotic manner:)
-		if (false === getenv('TRAVIS')) {
-			$this->fail("This test touches database. Add \"TRAVIS\" env variable if you want to run these test on your local instance.");
-		}
-
-		// Create user on which we will upload images and do testing
-		$userManager = OC::$server->getUserManager();
-		$username = 'testuser' . rand(0, PHP_INT_MAX);
-		$this->user = $userManager->createUser($username, 'password');
-		$this->loginAsUser($username);
-		// Get container to get classes using DI
-		$app = new App('facerecognition');
-		$this->container = $app->getContainer();
-
-		// Insantiate our context, that all tasks need
-		$appManager = $this->container->query('OCP\App\IAppManager');
-		$userManager = $this->container->query('OCP\IUserManager');
-		$rootFolder = $this->container->query('OCP\Files\IRootFolder');
-		$this->config = $this->container->query('OCP\IConfig');
-		$logger = $this->container->query('OCP\ILogger');
-		$this->context = new FaceRecognitionContext($appManager, $userManager, $rootFolder, $this->config);
-		$this->context->logger = new FaceRecognitionLogger($logger);
-	}
-
-	public function tearDown() {
-		$faceMgmtService = $this->container->query('OCA\FaceRecognition\FaceManagementService');
-		$faceMgmtService->resetAllForUser($this->user->getUID());
-
-		$this->user->delete();
-		parent::tearDown();
-	}
+class StaleImagesRemovalTaskTest extends IntegrationTestCase {
 
 	/**
 	 * Test that StaleImagesRemovalTask is not active, even though there should be some removals.


### PR DESCRIPTION
This is something I wanted to do for long time... And now I want to do it _before_ I continue adding stress tests for issue #137.

* Added one common abstract integration test case class
* removed setUp and tearDown methods from all other integration tests and made them child of that integration test case class
* I had to rename our "integration" directory due to case sensitive PHP paths
* Coverage and all functionality should stay the same, **this is just refactoring**

