### PR TITLE
Add memory limit settings to admin page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,21 @@ and in such way that your images never leave your Nextcloud instance. :smiley:
 
 The application listens to the creation of new image files, and queues them for
 later analysis. A scheduled task (Or admin on demand) take this queue, and
-analyze the images for looking faces and if possible identify them by comparing
-them with previous images assigned by the user.
+analyze the images for looking faces and if possible identify them grouping by
+similarity.
 
 ![App screenshots](/doc/face-recognition-screenshot.png "App screenshots")
 
 ## How to use it?
 
-First of all, the administrator must configure and execute the analysis. Once
-finished:
+The administrator must properly configure the application, and once it is
+working, the user must accept that he wants to allow the analysis of his images
+to discover his friends.
+Finally the user can use the application in three ways
 
- 1. In the user settings there is a 'Face Recognition' panel where the user can
-    see and rename all the faces of their friends.
+ 1. In the user settings there is a 'Face Recognition' panel where first of all
+    each user must enable the analysis. Once enabled, you will progressively see
+    the discovery of your friends, and you can assign them names.
  2. In the file application the user can search by typing your friend's name,
     and it will show all the photos.
  3. In the side panel of the file application, a 'Persons' tab is added where
@@ -73,10 +76,15 @@ Beware that this command can take a lot of CPU and memory! Before you put it to
 cron job, it is advised to try it out manually first, just to be sure you have
 all requirements and you have enough resources on your machine.
 
-Command is designed to be run continuously, so you will want to schedule it with cron to be executed every once in a while, together with a specified timeout. It can be run every 15 minutes with timeout of `-t 900` (so, it will stop itself automatically after 15 minutes and cron will start it again), or
-once a day with timeout of 2 hours, like `-t 7200`.
+Command is designed to be run continuously, so you will want to schedule it with
+cron to be executed every once in a while, together with a specified timeout. It
+can be run every 15 minutes with timeout of `-t 900` (so, it will stop itself
+automatically after 15 minutes and cron will start it again), or once a day with
+timeout of 2 hours, like `-t 7200`.
 
-If `user-id` is supplied, it will just loop over files of a given user.
+If `user-id` is supplied, it will just loop over files of a given user. Keep in
+mind that each user must enable the analysis individually, and otherwise this
+command will ignore the user.
 
 If `timeout` is supplied it will stop after the indicated seconds, and continue
 in the next execution. Use this value in conjunction with the times of the
@@ -90,4 +98,5 @@ This command will completely wipe out all images, faces and cluster of persons.
 It is ideal if you want to start from scratch for any reason. Beware that all
 images will have to be analyzed again!
 
-If `user-id` is supplied, it will just loop over files of a given user.
+If `user-id` is provided, it will just reset all the information of a particular
+user.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -37,6 +37,7 @@
 	</commands>
 	<settings>
 		<admin>OCA\FaceRecognition\Settings\Admin</admin>
+		<admin-section>OCA\FaceRecognition\Settings\AdminSection</admin-section>
 		<personal>OCA\FaceRecognition\Settings\Personal</personal>
 		<personal-section>OCA\FaceRecognition\Settings\PersonalSection</personal-section>
 	</settings>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -35,7 +35,7 @@ return ['routes' =>
 	[
 		'name' => 'setting#setUserValue',
 		'url' => '/setuservalue',
-		'verb' => 'GET'
+		'verb' => 'POST'
 	],
 	[
 		'name' => 'setting#getUserValue',
@@ -46,7 +46,7 @@ return ['routes' =>
 	[
 		'name' => 'setting#setAppValue',
 		'url' => '/setappvalue',
-		'verb' => 'GET'
+		'verb' => 'POST'
 	],
 	[
 		'name' => 'setting#getAppValue',

--- a/js/admin.js
+++ b/js/admin.js
@@ -7,6 +7,9 @@ $(document).ready(function() {
         ERROR:  3
     }
 
+    /*
+     * Progress
+     */
     function checkProgress() {
         $.get(OC.generateUrl('/apps/facerecognition/process')).done(function (progress) {
             if (progress.status) {
@@ -32,6 +35,9 @@ $(document).ready(function() {
         });
     }
 
+    /*
+     * Sensitivity
+     */
     function getSensitivity() {
         $.ajax({
             type: 'GET',
@@ -84,9 +90,74 @@ $(document).ready(function() {
     });
 
     /*
+     * MemoryLimits
+     */
+    function getMemoryLimits() {
+        $.ajax({
+            type: 'GET',
+            url: OC.generateUrl('apps/facerecognition/getappvalue'),
+            data: {
+                'type': 'memory-limits',
+            },
+            success: function (data) {
+                var memory = OC.Util.humanFileSize(data.value, false);
+                if (data.status === state.OK) {
+                    $('#memory-limits-text').val(memory);
+                }
+                $('#memory-limits-value').html(memory);
+            }
+        });
+    }
+
+    $('#memory-limits-text').on('input', function() {
+        var memory = OC.Util.computerFileSize (this.value);
+        $('#restore-memory-limits').show();
+        if (memory !== null) {
+            var human = OC.Util.humanFileSize(memory, false);
+            $('#memory-limits-value').html(human);
+            $('#save-memory-limits').show();
+        } else {
+            $('#save-memory-limits').hide();
+        }
+    });
+
+    $('#restore-memory-limits').on('click', function(event) {
+        event.preventDefault();
+        getMemoryLimits();
+
+        $('#restore-memory-limits').hide();
+        $('#save-memory-limits').hide();
+    });
+
+    $('#save-memory-limits').on('click', function(event) {
+        event.preventDefault();
+        var memoryInput = $('#memory-limits-text').val().toString();
+        var memory = OC.Util.computerFileSize(memoryInput);
+        $.ajax({
+            type: 'GET',
+            url: OC.generateUrl('apps/facerecognition/setappvalue'),
+            data: {
+                'type': 'memory-limits',
+                'value': memory
+            },
+            success: function (data) {
+                if (data.status === state.SUCCESS) {
+                    OC.Notification.showTemporary(t('facerecognition', 'The changes were saved. It will be taken into account in the next analysis.'));
+                    $('#restore-memory-limits').hide();
+                    $('#save-memory-limits').hide();
+                }
+                else {
+                    OC.Notification.showTemporary(t('facerecognition', 'The change could not be applied. Please, verify the memory format'));
+                }
+            }
+        });
+    });
+
+    /*
      * Get initial values.
      */
     getSensitivity();
+    getMemoryLimits();
     checkProgress();
 
     /*

--- a/js/admin.js
+++ b/js/admin.js
@@ -73,7 +73,7 @@ $(document).ready(function() {
         event.preventDefault();
         var sensitivity = $('#sensitivity-range').val().toString();
         $.ajax({
-            type: 'GET',
+            type: 'POST',
             url: OC.generateUrl('apps/facerecognition/setappvalue'),
             data: {
                 'type': 'sensitivity',
@@ -135,7 +135,7 @@ $(document).ready(function() {
         var memoryInput = $('#memory-limits-text').val().toString();
         var memory = OC.Util.computerFileSize(memoryInput);
         $.ajax({
-            type: 'GET',
+            type: 'POST',
             url: OC.generateUrl('apps/facerecognition/setappvalue'),
             data: {
                 'type': 'memory-limits',

--- a/js/admin.js
+++ b/js/admin.js
@@ -117,6 +117,7 @@ $(document).ready(function() {
             $('#memory-limits-value').html(human);
             $('#save-memory-limits').show();
         } else {
+            $('#memory-limits-value').html("...");
             $('#save-memory-limits').hide();
         }
     });
@@ -143,11 +144,13 @@ $(document).ready(function() {
             success: function (data) {
                 if (data.status === state.SUCCESS) {
                     OC.Notification.showTemporary(t('facerecognition', 'The changes were saved. It will be taken into account in the next analysis.'));
+                    var memory = OC.Util.humanFileSize(data.value, false);
+                    $('#memory-limits-text').val(memory);
                     $('#restore-memory-limits').hide();
                     $('#save-memory-limits').hide();
                 }
                 else {
-                    OC.Notification.showTemporary(t('facerecognition', 'The change could not be applied. Please, verify the memory format'));
+                    OC.Notification.showTemporary(t('facerecognition', 'The change could not be applied.'));
                 }
             }
         });

--- a/js/admin.js
+++ b/js/admin.js
@@ -150,7 +150,9 @@ $(document).ready(function() {
                     $('#save-memory-limits').hide();
                 }
                 else {
-                    OC.Notification.showTemporary(t('facerecognition', 'The change could not be applied.'));
+                    var message = t('facerecognition', 'The change could not be applied.');
+                    message += " - " + data.message;
+                    OC.Notification.showTemporary(message);
                 }
             }
         });

--- a/js/personal.js
+++ b/js/personal.js
@@ -109,7 +109,7 @@ View.prototype = {
     setEnabledUser: function (enabled) {
         var self = this;
         $.ajax({
-            type: 'GET',
+            type: 'POST',
             url: OC.generateUrl('apps/facerecognition/setuservalue'),
             data: {
                 'type': 'enabled',

--- a/lib/BackgroundJob/Tasks/AddMissingImagesTask.php
+++ b/lib/BackgroundJob/Tasks/AddMissingImagesTask.php
@@ -91,7 +91,7 @@ class AddMissingImagesTask extends FaceRecognitionBackgroundTask {
 			$userEnabled = $this->config->getUserValue($user, 'facerecognition', 'enabled', 'false');
 			if ($userEnabled === 'false') {
 				// Completely skip this task for this user, seems that disable analysis
-				$this->logDebug('Skipping image scan for user ' . $user . ' that has disabled the analysis');
+				$this->logInfo('Skipping image scan for user ' . $user . ' that has disabled the analysis');
 				continue;
 			}
 

--- a/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
+++ b/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
@@ -78,55 +78,53 @@ class CheckRequirementsTask extends FaceRecognitionBackgroundTask {
 		}
 
 		// Determine the system memory with some considerations.
-		$memory = MemoryLimits::getAvailableMemory();
-		if ($memory <= 0) {
+		$memoryAvailable = MemoryLimits::getAvailableMemory();
+		if ($memoryAvailable <= 0) {
 			// We cannot determine amount of memory to give to face recognition CNN.
 			// We will hardcode it here to 1GB, but plan is to expose this to user in future.
 			// TODO: allow user to choose "recognition quality", which will map to given memory.
 			// If user explicitely set something, we ignore getting memory from system.
 			$this->logDebug("Cannot detect amount of memory given to PHP process. Using 1GB for image processing");
-			$memory = 1024 * 1024 * 1024;
+			$memoryAvailable = 1024 * 1024 * 1024;
+		}
 
 		// Apply some prudent limits.
-		if ($memory < 1024 * 1024 * 1024) {
+		if ($memoryAvailable < 1024 * 1024 * 1024) {
 			$error_message =
 				"\n" .
-				"Seems that you have only " . intval($memory / (1024 * 1024)). "MB of memory given to PHP.\n" .
+				"Seems that you have only " . intval($memoryAvailable / (1024 * 1024)). "MB of memory given to PHP.\n" .
 				"Face recognition application requires at least 1 GB. You need to change your memory_limit in php.ini.\n" .
 				"Check https://secure.php.net/manual/en/ini.core.php#ini.memory-limit for details.\n" .
 				"If you already set this to unlimited, it seems your system is not having enough RAM memory.";
 			$this->logInfo($error_message);
 			return false;
 		} else {
-			$this->logDebug(sprintf('Found %d MB available to PHP.', $memory / (1024 * 1024)));
+			$this->logDebug(sprintf('Found %d MB available to PHP.', $systemMemory / (1024 * 1024)));
 			// No point going above 4GB ("4GB should be enough for everyone")
-			if ($memory > 4 * 1024 * 1024 * 1024) {
+			if ($memoryAvailable > 4 * 1024 * 1024 * 1024) {
 				$this->logDebug('Capping used memory to maximum of 4GB');
-				$memory = 4 * 1024 * 1024 * 1024;
+				$memoryAvailable = 4 * 1024 * 1024 * 1024;
 			}
 		}
 
 		// Apply admin setting limit.
 		$memorySetting = $this->config->getAppValue('facerecognition', 'memory-limits', '-1');
 		if ($memorySetting > 0) {
-			if ($memorySetting > $memory) {
+			if ($memorySetting > $memoryAvailable) {
 				$error_message =
 					"\n" .
-					"Seems that you configured" . intval($memorySetting / (1024 * 1024)) . " MB of memory, however, this exede"
-					"detected as maximum for PHP: " . intval($memory / (1024 * 1024)). "MB.\n" .
-					"You need to change your memory_limit in php.ini or 'Memory Limits' in settings.\n" .
-					"Check https://secure.php.net/manual/en/ini.core.php#ini.memory-limit for details.\n" .
-					"If you already set this to unlimited, it seems your system is not having enough RAM memory.";
+					"Seems that you configured" . intval($memorySetting / (1024 * 1024)) . " MB of memory, however, this exceeds"
+					"detected as maximum for PHP: " . intval($memoryAvailable / (1024 * 1024)). "MB.\n" .
+					"We will ignore the FaceRecognition settings, and we will limit to that.";
 				$this->logInfo($error_message);
-				return false;
 			}
 			else {
 				$this->logInfo("Applying the memory limit to " . intval($memorySetting / (1024*1024)) . "MB configured in settings.");
-				$memory = $memorySetting;
+				$memoryAvailable = $memorySetting;
 			}
 		}
 
-		$context->propertyBag['memory'] = $memory;
+		$context->propertyBag['memory'] = $memoryAvailable;
 
 		return true;
 	}

--- a/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
+++ b/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
@@ -99,7 +99,7 @@ class CheckRequirementsTask extends FaceRecognitionBackgroundTask {
 			$this->logInfo($error_message);
 			return false;
 		} else {
-			$this->logDebug(sprintf('Found %d MB available to PHP.', $systemMemory / (1024 * 1024)));
+			$this->logDebug(sprintf('Found %d MB available to PHP.', $memoryAvailable / (1024 * 1024)));
 			// No point going above 4GB ("4GB should be enough for everyone")
 			if ($memoryAvailable > 4 * 1024 * 1024 * 1024) {
 				$this->logDebug('Capping used memory to maximum of 4GB');

--- a/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
+++ b/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
@@ -113,7 +113,7 @@ class CheckRequirementsTask extends FaceRecognitionBackgroundTask {
 			if ($memorySetting > $memoryAvailable) {
 				$error_message =
 					"\n" .
-					"Seems that you configured" . intval($memorySetting / (1024 * 1024)) . " MB of memory, however, this exceeds"
+					"Seems that you configured" . intval($memorySetting / (1024 * 1024)) . " MB of memory, however, this exceeds" .
 					"detected as maximum for PHP: " . intval($memoryAvailable / (1024 * 1024)). "MB.\n" .
 					"We will ignore the FaceRecognition settings, and we will limit to that.";
 				$this->logInfo($error_message);

--- a/lib/Controller/SettingController.php
+++ b/lib/Controller/SettingController.php
@@ -131,11 +131,10 @@ class SettingController extends Controller {
 			case 'memory-limits':
 				if (is_numeric ($value)) {
 					// Apply prundent limits.
-					if ($value < 1 * 1024 * 1024) {
-						$value = 1 * 1024 * 1024;
+					if ($value < 1 * 1024 * 1024 * 1024) {
+						$value = 1 * 1024 * 1024 * 1024;
 						$status = self::STATE_ERROR;
-					}
-					else if ($value > 4 * 1024 * 1024) {
+					} else if ($value > 4 * 1024 * 1024 * 1024) {
 						$value = 4 * 1024 * 1024;
 						$status = self::STATE_ERROR;
 					}
@@ -182,8 +181,8 @@ class SettingController extends Controller {
 				// values used by the background task as a reference.
 				if ($value === '-1') {
 					$memory = MemoryLimits::getAvailableMemory();
-					if ($memory > 4 * 1024 * 1024)
-						$memory = 4 * 1024 * 1024;
+					if ($memory > 4 * 1024 * 1024 * 1024)
+						$memory = 4 * 1024 * 1024 * 1024;
 					$value = $memory;
 					$status = self::STATE_FALSE;
 				}

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -35,7 +35,7 @@ class Admin implements ISettings {
 	}
 
 	public function getSection() {
-		return 'overview';
+		return 'facerecognition';
 	}
 
 	public function getForm() {

--- a/lib/Settings/AdminSection.php
+++ b/lib/Settings/AdminSection.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace OCA\FaceRecognition\Settings;
+
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Settings\IIconSection;
+
+class AdminSection implements IIconSection
+{
+    /** @var IURLGenerator */
+    private $urlGenerator;
+    /** @var IL10N */
+    private $l;
+
+    public function __construct(IURLGenerator $urlGenerator, IL10N $l)
+    {
+        $this->urlGenerator = $urlGenerator;
+        $this->l = $l;
+    }
+
+    /**
+     * returns the relative path to an 16*16 icon describing the section.
+     *
+     * @returns string
+     */
+    public function getIcon()
+    {
+        return $this->urlGenerator->imagePath('facerecognition', 'app-dark.svg');
+    }
+
+    /**
+     * returns the ID of the section. It is supposed to be a lower case string,
+     *
+     * @returns string
+     */
+    public function getID()
+    {
+        return 'facerecognition';
+    }
+
+    /**
+     * returns the translated name as it should be displayed
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->l->t('Face Recognition');
+    }
+
+    /**
+     * returns priority for positioning
+     *
+     * @return int
+     */
+    public function getPriority()
+    {
+        return 10;
+    }
+}

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -25,6 +25,20 @@
 				<a id="save-sensitivity" class="icon-align icon-edit" style="display: none;" title="<?php p($l->t('Save'));?>" href="#"></a>
 			</p>
 		</div>
+		<div>
+			<h3>
+				<strong><?php p($l->t('Memory limits'));?></strong>
+			</h3>
+			<p class="settings-hint"><?php p($l->t('We limit the use of RAM according to your hardware, but you can change it. Higher memory may improve the results a bit, but it will also be unnecessarily slower.'));?>
+				<a target="_blank" rel="noreferrer noopener" class="icon-info" title="<?php p($l->t('Open Documentation'));?>" href="https://github.com/matiasdelellis/facerecognition/wiki/Performance-analysis-of-DLib%E2%80%99s-CNN-face-detection"></a>
+			</p>
+			<p>
+				<span><input type="memory" id="memory-limits-text" name="memory-limits-text" placeholder="<?php p($l->t('Use subfix as 2048 MB or 2G'));?>"></span>
+				<span id="memory-limits-value"class="span-highlighted">...</span>
+				<a id="restore-memory-limits" class="icon-align icon-history" style="display: none;" title="<?php p($l->t('Restore'));?>" href="#"></a>
+				<a id="save-memory-limits" class="icon-align icon-edit" style="display: none;" title="<?php p($l->t('Save'));?>" href="#"></a>
+			</p>
+		</div>
 		<h3><strong><?php p($l->t('Configuration information'));?> <span class="status success<?php if(!($_['pdlib-loaded'] && $_['model-present'])):?> error<?php endif;?>"></span></strong></h3>
 		<p><strong>Pdlib Version: </strong><?php p($_['pdlib-version']);?></p>
 		<p><strong>Models Version: </strong><?php p($_['model-version']);?></p>

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -29,7 +29,7 @@
 			<h3>
 				<strong><?php p($l->t('Memory limits'));?></strong>
 			</h3>
-			<p class="settings-hint"><?php p($l->t('We limit the use of RAM according to your hardware, but you can change it. Higher memory may improve the results a bit, but it will also be unnecessarily slower.'));?>
+			<p class="settings-hint"><?php p($l->t('Assigning more RAM can improve the results, but the analysis will be slower. Limiting its use you will get results faster, but for example you can lose the discovery of smaller faces in your images.'));?>
 				<a target="_blank" rel="noreferrer noopener" class="icon-info" title="<?php p($l->t('Open Documentation'));?>" href="https://github.com/matiasdelellis/facerecognition/wiki/Performance-analysis-of-DLib%E2%80%99s-CNN-face-detection"></a>
 			</p>
 			<p>


### PR DESCRIPTION
Thinking a little, I guess that the administrator's setting should be in terms of memory -which is the real limitation-, and not in terms of the redimensioning of the image. However I want to leave the maxImageArea as an advanced settings.

TODO:
 - [x] It is still ignored by the background task.
 - [x] Validate in setting controler.

It should already be usable.. You agree?.