### PR TITLE
Improving log when we hit error during image processing

### DIFF
--- a/lib/BackgroundJob/Tasks/ImageProcessingTask.php
+++ b/lib/BackgroundJob/Tasks/ImageProcessingTask.php
@@ -180,6 +180,8 @@ class ImageProcessingTask extends FaceRecognitionBackgroundTask {
 				if ($e->getMessage() === "std::bad_alloc") {
 					throw new \RuntimeException("Not enough memory to run face recognition! Please look FAQ at https://github.com/matiasdelellis/facerecognition/wiki/FAQ");
 				}
+				$this->logInfo('Faces found: 0. Image will be skipped because of the following error: ' . $e->getMessage());
+				$this->logDebug($e);
 				$this->imageMapper->imageProcessed($image, array(), 0, $e);
 			} finally {
 				$this->tempManager->clean();


### PR DESCRIPTION
As discussed in #148 , improving logging of errors when image cannot be processed. If verbose is set, user will get full stack trace, while if not - it will get only exception message.