### PR TITLE
Fix some app is not compliant..

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,13 +10,13 @@
 	<author>Matias De lellis</author>
 	<author>Branko Kokanovic</author>
 	<namespace>FaceRecognition</namespace>
+	<types>
+		<filesystem/>
+	</types>
 	<category>multimedia</category>
 	<website>https://github.com/matiasdelellis/facerecognition</website>
 	<bugs>https://github.com/matiasdelellis/facerecognition/issues</bugs>
 	<repository type="git">https://github.com/matiasdelellis/facerecognition.git</repository>
-	<types>
-		<filesystem/>
-	</types>
 	<dependencies>
 		<php min-version="7.0"/>
 		<nextcloud min-version="15" max-version="17"/>

--- a/lib/BackgroundJob/Tasks/StaleImagesRemovalTask.php
+++ b/lib/BackgroundJob/Tasks/StaleImagesRemovalTask.php
@@ -186,7 +186,7 @@ class StaleImagesRemovalTask extends FaceRecognitionBackgroundTask {
 
 			// Yield from time to time
 			$processed++;
-			if ($processed % 10 == 0) {
+			if ($processed % 10 === 0) {
 				$this->logDebug(sprintf('Processed %d/%d stale images for user %s', $processed, count($allImages), $userId));
 				yield;
 			}

--- a/lib/Command/BackgroundCommand.php
+++ b/lib/Command/BackgroundCommand.php
@@ -120,7 +120,7 @@ class BackgroundCommand extends Command {
 		if (!is_null($maxImageArea)) {
 			$maxImageArea = intval($maxImageArea);
 
-			if ($maxImageArea == 0) {
+			if ($maxImageArea === 0) {
 				throw new \InvalidArgumentException("Max image area must be positive number.");
 			}
 


### PR DESCRIPTION
Improve Issue #72 

Finally, the error of the type field is due only to the position. 

```
[matias@nube facerecognition]$ sudo -u apache php ../../occ app:check-code  facerecognition
[sudo] password for matias: 
Analysing /var/www/html/nextcloud/apps/facerecognition/lib/BackgroundJob/Tasks/AddMissingImagesTask.php
 2 errors
    line  123: OC_Util - Static method of private class must not be called
    line  124: OC_Util - Static method of private class must not be called
Analysing /var/www/html/nextcloud/apps/facerecognition/lib/BackgroundJob/Tasks/StaleImagesRemovalTask.php
 2 errors
    line  137: OC_Util - Static method of private class must not be called
    line  138: OC_Util - Static method of private class must not be called
Analysing /var/www/html/nextcloud/apps/facerecognition/appinfo/app.php
 1 errors
    line   31: OC_Util - Static method of private class must not be called
Analysing /var/www/html/nextcloud/apps/facerecognition/appinfo/update.php
 1 errors
    line   14: OC_DB - Static method of private class must not be called
Database schema error: Name of table *dbprefix*face_recognition_face_models is too long (28), max. 27 characters (21 characters for tables with autoincrement) + *dbprefix* allowed
Database schema error: Name of table *dbprefix*face_recognition_face_models is too long (28), max. 27 characters (21 characters for tables with autoincrement) + *dbprefix* allowed
Database schema error: Name of table *dbprefix*face_recognition_persons is too long (24), max. 27 characters (21 characters for tables with autoincrement) + *dbprefix* allowed
Database schema error: Name of table *dbprefix*face_recognition_images is too long (23), max. 27 characters (21 characters for tables with autoincrement) + *dbprefix* allowed
Database schema error: Name of table *dbprefix*face_recognition_faces is too long (22), max. 27 characters (21 characters for tables with autoincrement) + *dbprefix* allowed
Deprecated file found: /var/www/html/nextcloud/apps/facerecognition/appinfo/update.php - please use repair steps
App is not compliant
```

Note that:
 * line   14: OC_DB - Static method of private class must not be called
 * Deprecated file found: /var/www/html/nextcloud/apps/facerecognition/appinfo/update.php - please use repair steps

They are due to the migration of the last database... and I will delete it after publishing in the app store. So, there is only the use of OC_Utils and long tables name.. I guess pretty good.. :wink: 