### PR TITLE
Deletes persons without faces on change, fixes #137

### DIFF
--- a/lib/Db/FaceMapper.php
+++ b/lib/Db/FaceMapper.php
@@ -134,6 +134,20 @@ class FaceMapper extends QBMapper {
 	}
 
 	/**
+	 * Finds all faces contained in one image
+	 *
+	 * @param int $imageId Image for which to find all faces for
+	 */
+	public function findByImage(int $imageId) {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('id', 'image', 'person')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('image', $qb->createNamedParameter($imageId)));
+		$faces = $this->findEntities($qb);
+		return $faces;
+	}
+
+	/**
 	 * @param int $imageId Image for which to delete faces for
 	 */
 	public function removeFaces(int $imageId) {

--- a/lib/Db/PersonMapper.php
+++ b/lib/Db/PersonMapper.php
@@ -272,6 +272,25 @@ class PersonMapper extends QBMapper {
 	}
 
 	/**
+	 * Deletes person if it is empty (have no faces associated to it)
+	 *
+	 * @param int $personId Person to check if it should be deleted
+	 */
+	public function removeIfEmpty(int $personId) {
+		$sub = $this->db->getQueryBuilder();
+		$sub->select(new Literal('1'));
+		$sub->from("face_recognition_faces", "f")
+			->where($sub->expr()->eq('f.person', $sub->createParameter('person')));
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('id', $qb->createParameter('person')))
+			->andWhere('NOT EXISTS (' . $sub->getSQL() . ')')
+			->setParameter('person', $personId)
+			->execute();
+	}
+
+	/**
 	 * Checks if face with a given ID is in any cluster.
 	 *
 	 * @param int $faceId ID of the face to check

--- a/lib/Watcher.php
+++ b/lib/Watcher.php
@@ -172,7 +172,17 @@ class Watcher {
 			// note that invalidatePersons depends on existence of faces for a given image,
 			// and we must invalidate before we delete faces!
 			$this->personMapper->invalidatePersons($imageId);
+
+			// Fetch all faces to be deleted before deleting them, and then delete them
+			$facesToRemove = $this->faceMapper->findByImage($imageId);
 			$this->faceMapper->removeFaces($imageId);
+
+			// If any person is now without faces, remove those (empty) persons
+			foreach ($facesToRemove as $faceToRemove) {
+				if ($faceToRemove->getPerson() !== null) {
+					$this->personMapper->removeIfEmpty($faceToRemove->getPerson());
+				}
+			}
 		}
 	}
 
@@ -226,10 +236,20 @@ class Watcher {
 			// note that invalidatePersons depends on existence of faces for a given image,
 			// and we must invalidate before we delete faces!
 			$this->personMapper->invalidatePersons($imageId);
+
+			// Fetch all faces to be deleted before deleting them, and then delete them
+			$facesToRemove = $this->faceMapper->findByImage($imageId);
 			$this->faceMapper->removeFaces($imageId);
 
 			$image->setId($imageId);
 			$this->imageMapper->delete($image);
+
+			// If any person is now without faces, remove those (empty) persons
+			foreach ($facesToRemove as $faceToRemove) {
+				if ($faceToRemove->getPerson() !== null) {
+					$this->personMapper->removeIfEmpty($faceToRemove->getPerson());
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Using approach #1 from #137.

This change removes all persons that are without faces, after image
(file) is modified/deleted in hooks. When file is modified/deleted, we
are invalidating all persons for which there are faces on that image and
then removing faces. If this is last face for a given person, we didn't
delete that person, but we should (as there is no point having it), so
this fixed that.