### PR TITLE
Force as valid all clusters that remain the same between analyzes

### DIFF
--- a/lib/Db/PersonMapper.php
+++ b/lib/Db/PersonMapper.php
@@ -193,6 +193,14 @@ class PersonMapper extends QBMapper {
 
 				$oldFaces = $currentClusters[$newPerson];
 				if ($newFaces === $oldFaces) {
+					// Set cluster as valid now
+					$qb = $this->db->getQueryBuilder();
+					$qb
+						->update($this->getTableName())
+						->set("is_valid", $qb->createParameter('is_valid'))
+						->where($qb->expr()->eq('id', $qb->createNamedParameter($newPerson)))
+						->setParameter('is_valid', true, IQueryBuilder::PARAM_BOOL)
+						->execute();
 					continue;
 				}
 


### PR DESCRIPTION
Hi @stalker314314 

Sure you remember this:
 * https://github.com/matiasdelellis/facerecognition/issues/163#issuecomment-555216567

Despite all the latest efforts I found another case where we should force the revalidate the person.

Resumed steps to reproduce them:
 * Select a cluster with with 9 faces (of course the number is an example)
 * Delete a image that include an face of this cluster. This result on:
   - An cluster of 8 faces.
   - The person is invalid..
 * Execute the background task.
 * Well, this report `Found 1 changed persons for user user and model 1`

Hopefully as faces change, this group changes, and rebuilds them.. creating a new one.. 
But maybe the chinese-whispers algorithm returns exactly the same group of 8 faces, the comparison was indeed true, and the person was never revalidated.

In my case, I execute the background task over and over again and always see:

```
6/10 - Executing task CreateClustersTask (Create new persons or update existing persons)
	Found 0 faces without associated persons for user user and model 1
	Found 8 changed persons for user user and model 1
	973 faces found for clustering
	509 persons found after clustering
```


