### PR TITLE
Add a system configuration to configure the enabled mimetypes.

### DIFF
--- a/lib/Helper/Requirements.php
+++ b/lib/Helper/Requirements.php
@@ -16,29 +16,4 @@ class Requirements
 		return extension_loaded('pdlib');
 	}
 
-	/**
-	 * Determines if FaceRecognition can work with a givem image type. This is determined as
-	 * intersection of types that are supported in Nextcloud and types that are supported in DLIB.
-	 *
-	 * Dlib support can be found here:
-	 * https://github.com/davisking/dlib/blob/9b82f4b0f65a2152b4a4243c15709e5cb83f7044/dlib/image_loader/load_image.h#L21
-	 *
-	 * Note that Dlib supports these if it is compiled with them only! (with libjpeg, libpng...)
-	 *
-	 * Based on that and the fact that Nextcloud is superset of these, these are supported image types.
-	 *
-	 * @param string $mimeType MIME type to check if it supported
-	 * @return true if MIME type is supported, false otherwise
-	 */
-	public static function isImageTypeSupported(string $mimeType): bool {
-		if (
-				($mimeType === 'image/jpeg') or
-				($mimeType === 'image/png') or
-				($mimeType === 'image/bmp') or
-				($mimeType === 'image/gif')) {
-			return true;
-		} else {
-			return false;
-		}
-	}
 }

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -36,7 +36,6 @@ use OCP\Files\NotFoundException;
 
 use OCA\Files_Sharing\External\Storage as SharingExternalStorage;
 
-use OCA\FaceRecognition\Helper\Requirements;
 use OCA\FaceRecognition\Service\SettingsService;
 
 class FileService {
@@ -252,7 +251,7 @@ class FileService {
 				$results = $this->getPicturesFromFolder($node, $results);
 			}
 			else if ($node instanceof File) {
-				if (Requirements::isImageTypeSupported($node->getMimeType())) {
+				if ($this->settingsService->isAllowedMimetype($node->getMimeType())) {
 					$results[] = $node;
 				}
 			}

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -103,6 +103,10 @@ class SettingsService {
 	const MAXIMUM_IMAGE_AREA_KEY = 'max_image_area';
 	const DEFAULT_MAXIMUM_IMAGE_AREA = '-1';
 
+	/** System setting to enable mimetypes */
+	const SYSTEM_ENABLED_MIMETYPES = 'enabledFaceRecognitionMimetype';
+	private $allowedMimetypes = ['image/jpeg', 'image/png'];
+	private $cachedAllowedMimetypes = false;
 
 	/**
 	 * SettingsService
@@ -240,6 +244,21 @@ class SettingsService {
 
 	public function getMaximumImageArea(): int {
 		return intval($this->config->getAppValue(Application::APP_NAME, self::MAXIMUM_IMAGE_AREA_KEY, self::DEFAULT_MAXIMUM_IMAGE_AREA));
+	}
+
+	/**
+	 * System settings that must be configured according to the server configuration.
+	 */
+	public function isAllowedMimetype(string $mimetype): bool {
+		if (!$this->cachedAllowedMimetypes) {
+			$systemMimetypes = $this->config->getSystemValue(self::SYSTEM_ENABLED_MIMETYPES, $this->allowedMimetypes);
+			$this->allowedMimetypes = array_merge($this->allowedMimetypes, $systemMimetypes);
+			$this->allowedMimetypes = array_unique($this->allowedMimetypes);
+
+			$this->cachedAllowedMimetypes = true;
+		}
+
+		return in_array($mimetype, $this->allowedMimetypes);
 	}
 
 }

--- a/lib/Watcher.php
+++ b/lib/Watcher.php
@@ -40,8 +40,6 @@ use OCA\FaceRecognition\Db\FaceMapper;
 use OCA\FaceRecognition\Db\ImageMapper;
 use OCA\FaceRecognition\Db\PersonMapper;
 
-use OCA\FaceRecognition\Helper\Requirements;
-
 class Watcher {
 
 	/** @var ILogger Logger */
@@ -148,7 +146,7 @@ class Watcher {
 			return;
 		}
 
-		if (!Requirements::isImageTypeSupported($node->getMimeType())) {
+		if (!$this->settingsService->isAllowedMimetype($node->getMimeType())) {
 			// The file is not an image or the model does not support it
 			return;
 		}
@@ -233,7 +231,7 @@ class Watcher {
 			return;
 		}
 
-		if (!Requirements::isImageTypeSupported($node->getMimeType())) {
+		if (!$this->settingsService->isAllowedMimetype($node->getMimeType())) {
 			// The file is not an image or the model does not support it
 			return;
 		}

--- a/tests/Integration/AddMissingImagesTaskTest.php
+++ b/tests/Integration/AddMissingImagesTaskTest.php
@@ -96,13 +96,14 @@ class AddMissingImagesTaskTest extends IntegrationTestCase {
 		$view->mkdir('dir');
 		$view->file_put_contents("dir/foo4.txt", "content");
 		$view->file_put_contents("dir/foo5.bmp", "content");
+		$view->file_put_contents("dir/foo6.png", "content");
 		$view->mkdir('dir_nomedia');
 		$view->file_put_contents("dir_nomedia/.nomedia", "content");
 		$view->file_put_contents("dir_nomedia/foo7.jpg", "content");
 
 		$this->doMissingImageScan($this->user);
 
-		// We should find 3 images only - foo2.jpg, foo3.png and dir/foo5.bmp
+		// We should find 3 images only - foo2.jpg, foo3.png and dir/foo6.png. BMP mimetype (foo5.bmp) is not enabled by default.
 		$imageMapper = $this->container->query('OCA\FaceRecognition\Db\ImageMapper');
 		$this->assertEquals(3, count($imageMapper->findImagesWithoutFaces($this->user, ModelManager::DEFAULT_FACE_MODEL_ID)));
 		$this->assertEquals(3, $this->context->propertyBag['AddMissingImagesTask_insertedImages']);


### PR DESCRIPTION
It will be enabled in a similar way that enabble Previews adding in config.php
and array with with the supported mime types:

```
enabledFaceRecognitionMimetype => 
  array (
    0 => image/png',
    1 => 'image/jpeg',
    2 => 'image/gif',
    3 => 'image/bmp',
    4 => 'image/x-ms-bmp',
    5 => 'image/x-xbitmap'
  ),
```

By default just 'image/jpeg' and 'image/png' (Drop GIF and BMP), and although
I thought this opens the door to more formats, we are limited by IImage

See: https://github.com/nextcloud/server/blob/master/lib/private/legacy/image.php#L545

Basically GIF, JPEG, PNG, ¿XBM?, ¿WBMP?, and BMP. So it doesn't contribute much.
To add support to other formats we must be inspired by PreviewManager

See: https://github.com/nextcloud/server/tree/master/lib/private/Preview

Note that we can't just use this, because it restricts the size of exponentially
sized images (64xANY, 128xANY, 256xANY, 512xANY, 1024xANY).

All this said, it is still an improvement that leaves the configuration defined
to future.