### PR TITLE
Small rewriting of cluster creation conditioning.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ env:
     - DB=mysql
     - DB=pgsql
     - DB=sqlite
-    - DB=mysql CORE_BRANCH=master
-    - DB=pgsql CORE_BRANCH=master
-    - DB=sqlite CORE_BRANCH=master
+    - DB=mysql CORE_BRANCH=stable19
+    - DB=pgsql CORE_BRANCH=stable19
+    - DB=sqlite CORE_BRANCH=stable19
 
 before_install:
   # Installing pdlib (install dlib from repo and compile pdlib on top of it)

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - ./configure --enable-debug && make && sudo make install
   - echo "extension=pdlib.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
   - popd
-
+  - sudo apt-get install nodejs-dev node-gyp libssl1.0-dev
   - sudo apt-get install npm
   - sudo npm config set strict-ssl false
   - make

--- a/lib/BackgroundJob/Tasks/CreateClustersTask.php
+++ b/lib/BackgroundJob/Tasks/CreateClustersTask.php
@@ -208,7 +208,7 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 		$oldestFaceTimestamp = $oldestFace->creationTime->getTimestamp();
 		$currentTimestamp = (new \DateTime())->getTimestamp();
 		$this->logDebug(sprintf('Oldest face without persons for user %s and model %d is from %s',
-		                $userId, $modelId, $face->creationTime->format('Y-m-d H:i:s')));
+		                $userId, $modelId, $oldestFace->creationTime->format('Y-m-d H:i:s')));
 
 		// todo: get rid of magic numbers (move to config)
 		if ($currentTimestamp - $oldestFaceTimestamp > 2 * 60 * 60)
@@ -221,7 +221,7 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 		return $this->personMapper->countPersons($userId, $modelId, true) > 0;
 	}
 
-	private function needRecreateBySettings($userId, $modelId): bool {
+	private function needRecreateBySettings($userId): bool {
 		return $this->settingsService->getNeedRecreateClusters($userId);
 	}
 

--- a/lib/BackgroundJob/Tasks/CreateClustersTask.php
+++ b/lib/BackgroundJob/Tasks/CreateClustersTask.php
@@ -117,7 +117,7 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 			if ($forceRecreate) {
 				$this->logInfo('Clusters already exist, but there was some change that requires recreating the clusters');
 			}
-			else if ($haveEnoughFaces || $haveStales) {
+			else if ($haveEnoughFaces || $haveStaled) {
 				$this->logInfo('Face clustering will be recreated with new information or changes');
 			}
 			else {

--- a/lib/BackgroundJob/Tasks/CreateClustersTask.php
+++ b/lib/BackgroundJob/Tasks/CreateClustersTask.php
@@ -110,7 +110,7 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 		//
 		$hasPersons = $this->personMapper->countPersons($userId, $modelId) > 0;
 		if ($hasPersons) {
-			$forceRecreate = $this->needRecreateBySettings($userId, $modelId);
+			$forceRecreate = $this->needRecreateBySettings($userId);
 			$haveEnoughFaces = $this->hasNewFacesToRecreate($userId, $modelId);
 			$haveStaled = $this->hasStalePersonsToRecreate($userId, $modelId);
 

--- a/lib/Db/ImageMapper.php
+++ b/lib/Db/ImageMapper.php
@@ -135,7 +135,7 @@ class ImageMapper extends QBMapper {
 		return (int)$data[0];
 	}
 
-	public function countUserImages(string $userId, $model): int {
+	public function countUserImages(string $userId, int $model, $processed = false): int {
 		$qb = $this->db->getQueryBuilder();
 		$query = $qb
 			->select($qb->createFunction('COUNT(' . $qb->getColumnName('id') . ')'))
@@ -144,24 +144,12 @@ class ImageMapper extends QBMapper {
 			->andWhere($qb->expr()->eq('model', $qb->createParameter('model')))
 			->setParameter('user', $userId)
 			->setParameter('model', $model);
-		$resultStatement = $query->execute();
-		$data = $resultStatement->fetch(\PDO::FETCH_NUM);
-		$resultStatement->closeCursor();
 
-		return (int)$data[0];
-	}
+		if ($processed) {
+			$query->andWhere($qb->expr()->eq('is_processed', $qb->createParameter('is_processed')))
+			      ->setParameter('is_processed', true);
+		}
 
-	public function countUserProcessedImages(string $userId, $model): int {
-		$qb = $this->db->getQueryBuilder();
-		$query = $qb
-			->select($qb->createFunction('COUNT(' . $qb->getColumnName('id') . ')'))
-			->from($this->getTableName())
-			->where($qb->expr()->eq('user', $qb->createParameter('user')))
-			->andWhere($qb->expr()->eq('model', $qb->createParameter('model')))
-			->andWhere($qb->expr()->eq('is_processed', $qb->createParameter('is_processed')))
-			->setParameter('user', $userId)
-			->setParameter('model', $model)
-			->setParameter('is_processed', True);
 		$resultStatement = $query->execute();
 		$data = $resultStatement->fetch(\PDO::FETCH_NUM);
 		$resultStatement->closeCursor();

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -184,12 +184,14 @@ class SettingsService {
 		$this->config->setUserValue($userId ?? $this->userId, Application::APP_NAME, self::USER_RECREATE_CLUSTERS_KEY, $needRecreate ? "true" : "false");
 	}
 
-	public function getForceCreateClusters ($userId = null): bool {
+	// Private function used only on tests
+	public function _getForceCreateClusters ($userId = null): bool {
 		$forceCreate = $this->config->getUserValue($userId ?? $this->userId, Application::APP_NAME, self::FORCE_CREATE_CLUSTERS_KEY, self::DEFAULT_FORCE_CREATE_CLUSTERS);
 		return ($forceCreate === 'true');
 	}
 
-	public function setForceCreateClusters (bool $forceCreate, $userId = null) {
+	// Private function used only on tests
+	public function _setForceCreateClusters (bool $forceCreate, $userId = null) {
 		$this->config->setUserValue($userId ?? $this->userId, Application::APP_NAME, self::FORCE_CREATE_CLUSTERS_KEY, $forceCreate ? "true" : "false");
 	}
 


### PR DESCRIPTION
The idea was to improve the initial conditions of recreation, but it became a little rewrite to improve the reading of the code.

It still has a bug, that I noticed a long time ago but never solved it.. and the issue #290 made me remember. :sweat_smile:
Basically, if you have more than 100 photos, analyzed or not, the clusters will be created. :disappointed: 