### PR TITLE
Use the original image to get landmarks and descriptors.

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -46,6 +46,7 @@
 	</repair-steps>
 	<commands>
 		<command>OCA\FaceRecognition\Command\BackgroundCommand</command>
+		<command>OCA\FaceRecognition\Command\MigrateCommand</command>
 		<command>OCA\FaceRecognition\Command\ProgressCommand</command>
 		<command>OCA\FaceRecognition\Command\ResetCommand</command>
 		<command>OCA\FaceRecognition\Command\SetupCommand</command>

--- a/lib/BackgroundJob/Tasks/ImageProcessingTask.php
+++ b/lib/BackgroundJob/Tasks/ImageProcessingTask.php
@@ -148,7 +148,7 @@ class ImageProcessingTask extends FaceRecognitionBackgroundTask {
 					$landmarks = $this->model->detectLandmarks($tempImage->getImagePath(), $normFace);
 
 					// Get descriptor of face from model
-					$descriptor = $this->model->computeDescriptor($tempImage->getImagePath(), $landmarks, 100);
+					$descriptor = $this->model->computeDescriptor($tempImage->getImagePath(), $landmarks);
 
 					// Convert from dictionary of faces to our Face Db Entity and put Landmarks and descriptor
 					$face = Face::fromModel($image->getId(), $normFace);

--- a/lib/BackgroundJob/Tasks/ImageProcessingTask.php
+++ b/lib/BackgroundJob/Tasks/ImageProcessingTask.php
@@ -143,18 +143,16 @@ class ImageProcessingTask extends FaceRecognitionBackgroundTask {
 
 				$faces = array();
 				foreach ($rawFaces as $rawFace) {
-					// Get landmarks of face from model
-					$rawLandmarks = $this->model->detectLandmarks($tempImage->getTempPath(), $rawFace);
-					// Get descriptor of face from model
-					$descriptor = $this->model->computeDescriptor($tempImage->getTempPath(), $rawLandmarks);
-
-					// Normalize face and landmarks from model to original size
+					// Normalize face and get landmarks of face from model to original size
 					$normFace = $this->getNormalizedFace($rawFace, $tempImage->getRatio());
-					$normLandmarks = $this->getNormalizedLandmarks($rawLandmarks['parts'], $tempImage->getRatio());
+					$landmarks = $this->model->detectLandmarks($tempImage->getImagePath(), $normFace);
+
+					// Get descriptor of face from model
+					$descriptor = $this->model->computeDescriptor($tempImage->getImagePath(), $landmarks, 100);
 
 					// Convert from dictionary of faces to our Face Db Entity and put Landmarks and descriptor
 					$face = Face::fromModel($image->getId(), $normFace);
-					$face->landmarks = $normLandmarks;
+					$face->landmarks = $landmarks['parts'];
 					$face->descriptor = $descriptor;
 
 					$faces[] = $face;
@@ -258,21 +256,6 @@ class ImageProcessingTask extends FaceRecognitionBackgroundTask {
 		$face['bottom'] = intval(round($rawFace['bottom']*$ratio));
 		$face['detection_confidence'] = $rawFace['detection_confidence'];
 		return $face;
-	}
-
-	/**
-	 * Helper method, to normalize landmarks sizes back to original dimensions, based on ratio
-	 *
-	 */
-	private function getNormalizedLandmarks(array $rawLandmarks, float $ratio): array {
-		$landmarks = [];
-		foreach ($rawLandmarks as $rawLandmark) {
-			$landmark = [];
-			$landmark['x'] = intval(round($rawLandmark['x']*$ratio));
-			$landmark['y'] = intval(round($rawLandmark['y']*$ratio));
-			$landmarks[] = $landmark;
-		}
-		return $landmarks;
 	}
 
 }

--- a/lib/BackgroundJob/Tasks/ImageProcessingTask.php
+++ b/lib/BackgroundJob/Tasks/ImageProcessingTask.php
@@ -136,7 +136,7 @@ class ImageProcessingTask extends FaceRecognitionBackgroundTask {
 				}
 
 				// Get faces in the temporary image
-				$tempImagePath = $tempImage->getTempPath();
+				$tempImagePath = $tempImage->getResizedImagePath();
 				$rawFaces = $this->model->detectFaces($tempImagePath);
 
 				$this->logInfo('Faces found: ' . count($rawFaces));
@@ -145,10 +145,10 @@ class ImageProcessingTask extends FaceRecognitionBackgroundTask {
 				foreach ($rawFaces as $rawFace) {
 					// Normalize face and get landmarks of face from model to original size
 					$normFace = $this->getNormalizedFace($rawFace, $tempImage->getRatio());
-					$landmarks = $this->model->detectLandmarks($tempImage->getImagePath(), $normFace);
+					$landmarks = $this->model->detectLandmarks($tempImage->getOrientedImagePath(), $normFace);
 
 					// Get descriptor of face from model
-					$descriptor = $this->model->computeDescriptor($tempImage->getImagePath(), $landmarks);
+					$descriptor = $this->model->computeDescriptor($tempImage->getOrientedImagePath(), $landmarks);
 
 					// Convert from dictionary of faces to our Face Db Entity and put Landmarks and descriptor
 					$face = Face::fromModel($image->getId(), $normFace);

--- a/lib/Command/MigrateCommand.php
+++ b/lib/Command/MigrateCommand.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * @copyright Copyright (c) 2020, Matias De lellis <mati86dl@gmail.com>
+ * @copyright Copyright (c) 2019, Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @author Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\FaceRecognition\Command;
+
+use OCP\IUserManager;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use OCA\FaceRecognition\Db\FaceMapper;
+
+use OCA\FaceRecognition\Model\SettingsManager;
+
+use OCA\FaceRecognition\Service\FaceManagementService;
+
+class MigrateCommand extends Command {
+
+	/** @var FaceManagementService */
+	protected $faceManagementService;
+
+	/** @var IUserManager */
+	protected $userManager;
+
+	/** @var ModelManager */
+	protected $modelManager;
+
+	/** @var FaceMapper */
+	protected $faceMapper;
+
+	/**
+	 * @param FaceManagementService $faceManagementService
+	 * @param IUserManager $userManager
+	 */
+	public function __construct(FaceManagementService $faceManagementService,
+	                            IUserManager          $userManager,
+	                            ModelManager          $modelManager,
+	                            FaceMapper            $faceMapper)
+	{
+		parent::__construct();
+
+		$this->faceManagementService = $faceManagementService;
+		$this->userManager           = $userManager;
+		$this->modelManager          = $modelManager;
+		$this->faceMapper            = $faceMapper;
+	}
+
+	protected function configure() {
+		$this
+			->setName('face:migrate')
+			->setDescription(
+				'Migrate the faces found in a model and analyze with the current model.')
+			->addOption(
+				'user_id',
+				'u',
+				InputOption::VALUE_REQUIRED,
+				'Migrate data for a given user only. If not given, migrate everything for all users.',
+				null
+			)
+			->addOption(
+				'model',
+				'm',
+				InputOption::VALUE_OPTIONAL,
+				'The identifier number of the model to migrate',
+				null
+			);
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		// Extract user, if any
+		//
+		$userId = $input->getOption('user_id');
+		if (!is_null($userId)) {
+			$user = $this->userManager->get($userId);
+			if ($user === null) {
+				$output->writeln("User with id <$userId> is unknown.");
+				return 1;
+			}
+		}
+
+		$modelId = $input->getOption('model');
+		if (is_null($modelId)) {
+			$this->logger->writeln("You must indicate the ID of the model to migrate");
+			return 1;
+		}
+
+		$model = $this->modelManager->getModel($modelId);
+		if (is_null($model)) {
+			$this->logger->writeln("Invalid model Id");
+			return 1;
+		}
+
+		if (!$model->isIstalled()) {
+			$this->logger->writeln("The model <$modelId> is not installed");
+			return 1;
+		}
+
+		$currentModel = $this->modelManager->getCurrentModel();
+		$currentModelId = (!is_null($currentModel)) ? $currentModel->getId() : -1;
+
+		if ($currentModelId === $modelId) {
+			$this->logger->writeln("The proposed model <$modelId> to migrate must be other than the current one <$currentModelId>");
+			return 1;
+		}
+
+		if (!$this->$faceManagementService->hasDataForUser($userId, $modelId)) {
+			$this->logger->writeln("The proposed model <$modelId> to migrate is empty");
+			return 1;
+		}
+
+		if ($this->$faceManagementService->hasDataForUser($userId, $modelId)) {
+			$this->logger->writeln("The current model <$currentModelId> already has data. You cannot migrate to a used model.");
+			return 1;
+		}
+
+
+	}
+
+}

--- a/lib/Command/ResetCommand.php
+++ b/lib/Command/ResetCommand.php
@@ -73,6 +73,13 @@ class ResetCommand extends Command {
 				null
 			)
 			->addOption(
+				'model',
+				null,
+				InputOption::VALUE_NONE,
+				'Reset current model.',
+				null
+			)
+			->addOption(
 				'image-errors',
 				null,
 				InputOption::VALUE_NONE,
@@ -114,6 +121,11 @@ class ResetCommand extends Command {
 			$output->writeln('Reset successfully done');
 			return 0;
 		}
+		else if ($input->getOption('model')) {
+			$this->resetModel($user);
+			$output->writeln('Reset model successfully done');
+			return 0;
+		}
 		else if ($input->getOption('image-errors')) {
 			$this->resetImageErrors($user);
 			$output->writeln('Reset image errors done');
@@ -140,6 +152,10 @@ class ResetCommand extends Command {
 
 	private function resetAll($user) {
 		$this->faceManagementService->resetAll($user);
+	}
+
+	private function resetModel($user) {
+		$this->faceManagementService->resetModel($user);
 	}
 
 }

--- a/lib/Db/ImageMapper.php
+++ b/lib/Db/ImageMapper.php
@@ -311,4 +311,19 @@ class ImageMapper extends QBMapper {
 			->where($qb->expr()->eq('user', $qb->createNamedParameter($userId)))
 			->execute();
 	}
+
+	/**
+	 * Deletes all images from that user and Model
+	 *
+	 * @param string $userId User to drop images from table.
+	 * @param int $modelId model to drop images from table.
+	 */
+	public function deleteUserModel(string $userId, $modelId) {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('user', $qb->createNamedParameter($userId)))
+			->andWhere($qb->expr()->eq('model', $qb->createNamedParameter($modelId)))
+			->execute();
+	}
+
 }

--- a/lib/Db/ImageMapper.php
+++ b/lib/Db/ImageMapper.php
@@ -54,6 +54,19 @@ class ImageMapper extends QBMapper {
 
 	/**
 	 * @param string $userId Id of user
+	 * @param int $modelId Id of model to get
+	 */
+	public function findAll(string $userId, int $modelId) {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('id', 'file', 'is_processed', 'error', 'last_processed_time', 'processing_duration')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('user', $qb->createNamedParameter($userId)))
+			->andWhere($qb->expr()->eq('model', $qb->createNamedParameter($modelId)));
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * @param string $userId Id of user
 	 * @param int $modelId Id of model
 	 * @param int $fileId Id of file to get Image
 	 */

--- a/lib/Db/PersonMapper.php
+++ b/lib/Db/PersonMapper.php
@@ -300,6 +300,24 @@ class PersonMapper extends QBMapper {
 	}
 
 	/**
+	 * Deletes all persons from that user and model
+	 *
+	 * @param string $userId ID of user for drop from table
+	 * @param string $modelId model for drop from table
+	 */
+	public function deleteUserModel(string $userId, int $modelId) {
+		//TODO: Make it atomic
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('id', $qb->createParameter('person')));
+
+		$persons = $this->findAll($userId, $modelId);
+		foreach ($persons as $person) {
+			$qb->setParameter('person', $person->getId())->execute();
+		}
+	}
+
+	/**
 	 * Deletes person if it is empty (have no faces associated to it)
 	 *
 	 * @param int $personId Person to check if it should be deleted

--- a/lib/Helper/TempImage.php
+++ b/lib/Helper/TempImage.php
@@ -81,6 +81,15 @@ class TempImage extends Image {
 	}
 
 	/**
+	 * Get the path of orig image
+	 *
+	 * @return string
+	 */
+	public function getImagePath(): string {
+		return $this->imagePath;
+	}
+
+	/**
 	 * Obtain the ratio of the temporary image against the original
 	 *
 	 * @return float

--- a/lib/Helper/TempImage.php
+++ b/lib/Helper/TempImage.php
@@ -34,7 +34,10 @@ class TempImage extends Image {
 	private $imagePath;
 
 	/** @var string */
-	private $tempPath;
+	private $orientedImagePath;
+
+	/** @var string */
+	private $resizedImagePath;
 
 	/** @var string */
 	private $preferredMimeType;
@@ -72,12 +75,12 @@ class TempImage extends Image {
 	}
 
 	/**
-	 * Get the path of temporary image
+	 * Get the path of orig image
 	 *
 	 * @return string
 	 */
-	public function getTempPath(): string {
-		return $this->tempPath;
+	public function getImagePath(): string {
+		return $this->imagePath;
 	}
 
 	/**
@@ -85,8 +88,17 @@ class TempImage extends Image {
 	 *
 	 * @return string
 	 */
-	public function getImagePath(): string {
-		return $this->imagePath;
+	public function getOrientedImagePath(): string {
+		return $this->orientedImagePath;
+	}
+
+	/**
+	 * Get the path of temporary image
+	 *
+	 * @return string
+	 */
+	public function getResizedImagePath(): string {
+		return $this->resizedImagePath;
 	}
 
 	/**
@@ -119,7 +131,6 @@ class TempImage extends Image {
 	 */
 	private function prepareImage() {
 		$this->loadFromFile($this->imagePath);
-		$this->fixOrientation();
 
 		if (!$this->valid()) {
 			throw new \RuntimeException("Image is not valid, probably cannot be loaded");
@@ -131,10 +142,18 @@ class TempImage extends Image {
 			return;
 		}
 
-		$this->ratio = $this->resizeImage();
-		$this->tempPath = $this->tempManager->getTemporaryFile();
+		if ($this->getOrientation() > 1) {
+			$this->fixOrientation();
+			$this->orientedImagePath = $this->tempManager->getTemporaryFile();
+			$this->save($this->orientedImagePath, $this->preferredMimeType);
+		} else {
+			$this->orientedImagePath = $this->imagePath;
+		}
 
-		$this->save($this->tempPath, $this->preferredMimeType);
+		$this->ratio = $this->resizeImage();
+		$this->resizedImagePath = $this->tempManager->getTemporaryFile();
+
+		$this->save($this->resizedImagePath, $this->preferredMimeType);
 	}
 
 	/**

--- a/lib/Service/FaceManagementService.php
+++ b/lib/Service/FaceManagementService.php
@@ -102,7 +102,6 @@ class FaceManagementService {
 		return ($facesCount > 0);
 	}
 
-
 	/**
 	 * Deletes all faces, images and persons found. IF no user is given, resetting is executed for all users.
 	 *
@@ -124,6 +123,36 @@ class FaceManagementService {
 		$this->faceMapper->deleteUserFaces($userId);
 		$this->personMapper->deleteUserPersons($userId);
 		$this->imageMapper->deleteUserImages($userId);
+
+		$this->settingsService->setUserFullScanDone(false, $userId);
+	}
+
+	/**
+	 * Deletes all faces, images and persons found. If no user is given, resetting is executed for all users.
+	 *
+	 * @param IUser|null $user Optional user to execute resetting for
+	 * @param Int $modelId Optional model to clean
+	 */
+	public function resetModel(IUser $user = null, int $modelId = -1) {
+		if ($modelId === -1) {
+			$modelId = $this->settingsService->getCurrentFaceModel();
+		}
+		$eligible_users = $this->getEligiblesUserId($user);
+		foreach($eligible_users as $userId) {
+			$this->resetModelForUser($userId, $modelId);
+		}
+	}
+
+	/**
+	 * Deletes all faces, images and persons found for a given user.
+	 *
+	 * @param string $user ID of user to execute resetting for
+	 * @param Int $modelId model to clean
+	 */
+	public function resetModelForUser(string $userId, $modelId) {
+		$this->personMapper->deleteUserModel($userId, $modelId);
+		$this->faceMapper->deleteUserModel($userId, $modelId);
+		$this->imageMapper->deleteUserModel($userId, $modelId);
 
 		$this->settingsService->setUserFullScanDone(false, $userId);
 	}

--- a/lib/Service/FaceManagementService.php
+++ b/lib/Service/FaceManagementService.php
@@ -73,6 +73,37 @@ class FaceManagementService {
 	}
 
 	/**
+	 * Check if the current model has data on db
+	 *
+	 * @param IUser|null $user Optional user to check
+	 * @param Int $modelId Optional model to check
+	 */
+	public function hasData(IUser $user = null, int $modelId = -1) {
+		if ($modelId === -1) {
+			$modelId = $this->settingsService->getCurrentFaceModel();
+		}
+		$eligible_users = $this->getEligiblesUserId($user);
+		foreach ($eligible_users as $userId) {
+			if ($this->hasDataForUser($userId, $modelId)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Check if the current model has data on db for user
+	 *
+	 * @param string $user ID of user to check
+	 * @param Int $modelId model to check
+	 */
+	public function hasDataForUser(string $userId, int $modelId) {
+		$facesCount = $this->faceMapper->countFaces($userId, $modelId);
+		return ($facesCount > 0);
+	}
+
+
+	/**
 	 * Deletes all faces, images and persons found. IF no user is given, resetting is executed for all users.
 	 *
 	 * @param IUser|null $user Optional user to execute resetting for


### PR DESCRIPTION
Well,
I already insisted many times for the degradation of the images when resizing, etc. :sweat_smile: 

Note that when dlib compute the descriptor, it already generates a cut of the face resizing it to 150px. This is yet another degradation, and therefore is better to pass the original image, and let dlib do its magic. :smiley: 

Well, a little test, with our The Big Bang Theory test suite.. :sweat_smile:

![TBBT-Bad-Clusters-Git-Master](https://user-images.githubusercontent.com/733715/87237265-8deab200-c3ca-11ea-99d8-a29ec2fa29b2.png)
![TBBT-Bad-Clusters-Proposed](https://user-images.githubusercontent.com/733715/87237267-95aa5680-c3ca-11ea-8522-472df760544a.png)

* The first image are the clusters that have an error, with the master branch and the default parameters. (Model 1, 0.4 and 0.99)
* The second image is with the proposed code, and of course the same parameters.

It is not a substantial improvement, but an improvement in the end. :sweat_smile: 
I test it several times, and I always get the same difference.