### PR TITLE
Add an option to not cluster smaller faces.

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -37,7 +37,6 @@ $(document).ready(function() {
                 var desc = t('facerecognition', 'The analysis is not started yet');
                 desc += ' - ';
                 desc += n('facerecognition', '%n image in queue', '%n images in queue', progress.totalImages);
-
                 $('#progress-text').html(desc);
             }
         });
@@ -215,6 +214,59 @@ $(document).ready(function() {
         });
     });
 
+    /*
+     * Face Size
+     */
+    function getMinFaceSize() {
+        $.ajax({
+            type: 'GET',
+            url: OC.generateUrl('apps/facerecognition/getappvalue'),
+            data: {
+                'type': 'min_face_size',
+            },
+            success: function (data) {
+                if (data.status === state.OK) {
+                    var minFace = parseInt(data.value);
+                    $('#min-face-range').val(minFace);
+                    $('#min-face-value').html(minFace);
+                }
+            }
+        });
+    }
+
+    $('#min-face-range').on('input', function() {
+        $('#min-face-value').html(this.value);
+        $('#restore-min-face').show();
+        $('#save-min-face').show();
+    });
+
+    $('#restore-min-face').on('click', function(event) {
+        event.preventDefault();
+        getMinFaceSize();
+
+        $('#restore-min-face').hide();
+        $('#save-min-face').hide();
+    });
+
+    $('#save-min-face').on('click', function(event) {
+        event.preventDefault();
+        var minFace = $('#min-face-range').val().toString();
+        $.ajax({
+            type: 'POST',
+            url: OC.generateUrl('apps/facerecognition/setappvalue'),
+            data: {
+                'type': 'min_face_size',
+                'value': minFace
+            },
+            success: function (data) {
+                if (data.status === state.SUCCESS) {
+                    OC.Notification.showTemporary(t('facerecognition', 'The changes were saved. It will be taken into account in the next analysis.'));
+                    $('#restore-min-face').hide();
+                    $('#save-min-face').hide();
+                }
+            }
+        });
+    });
 
     /*
      * Show not clustered people
@@ -264,6 +316,7 @@ $(document).ready(function() {
     getImageArea();
     getSensitivity();
     getMinConfidence();
+    getMinFaceSize();
     getNotGrouped();
 
     checkProgress();

--- a/lib/BackgroundJob/Tasks/CreateClustersTask.php
+++ b/lib/BackgroundJob/Tasks/CreateClustersTask.php
@@ -278,14 +278,14 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 			for ($i = 0; $i < $faces_count; $i++) {
 				$face1 = $faces[$i];
 				if (($face1->confidence < $min_confidence) ||
-				    ($face1->height() < $min_face_size)) {
+				    (max($face1->height(), $face1->width()) < $min_face_size)) {
 					$edges[] = array($i, $i);
 					continue;
 				}
 				for ($j = $i; $j < $faces_count; $j++) {
 					$face2 = $faces[$j];
 					if (($face2->confidence < $min_confidence) ||
-					    ($face2->height() < $min_face_size)) {
+					    (max($face2->height(), $face2->width()) < $min_face_size)) {
 						continue;
 					}
 					$distance = dlib_vector_length($face1->descriptor, $face2->descriptor);
@@ -300,14 +300,14 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 			for ($i = 0; $i < $faces_count; $i++) {
 				$face1 = $faces[$i];
 				if (($face1->confidence < $min_confidence) ||
-				    ($face1->height() < $min_face_size)) {
+				    (max($face1->height(), $face1->width()) < $min_face_size)) {
 					$edges[] = array($i, $i);
 					continue;
 				}
 				for ($j = $i; $j < $faces_count; $j++) {
 					$face2 = $faces[$j];
 					if (($face2->confidence < $min_confidence) ||
-					    ($face2->height() < $min_face_size)) {
+					    (max($face2->height(), $face2->width()) < $min_face_size)) {
 						continue;
 					}
 					// todo: can't this distance be a method in $face1->distance($face2)?

--- a/lib/BackgroundJob/Tasks/CreateClustersTask.php
+++ b/lib/BackgroundJob/Tasks/CreateClustersTask.php
@@ -265,22 +265,27 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 	}
 
 	private function getNewClusters(array $faces): array {
-		// Create edges for chinese whispers
-		$euclidean = new Euclidean();
+		// Clustering parameters
 		$sensitivity = $this->settingsService->getSensitivity();
 		$min_confidence = $this->settingsService->getMinimumConfidence();
+		$min_face_size = $this->settingsService->getMinimumFaceSize();
+
+		// Create edges for chinese whispers
 		$edges = array();
 
 		if (version_compare(phpversion('pdlib'), '1.0.2', '>=')) {
-			for ($i = 0, $face_count1 = count($faces); $i < $face_count1; $i++) {
+			$faces_count = count($faces);
+			for ($i = 0; $i < $faces_count; $i++) {
 				$face1 = $faces[$i];
-				if ($face1->confidence < $min_confidence) {
+				if (($face1->confidence < $min_confidence) ||
+				    ($face1->height() < $min_face_size)) {
 					$edges[] = array($i, $i);
 					continue;
 				}
-				for ($j = $i, $face_count2 = count($faces); $j < $face_count2; $j++) {
+				for ($j = $i; $j < $faces_count; $j++) {
 					$face2 = $faces[$j];
-					if ($face2->confidence < $min_confidence) {
+					if (($face2->confidence < $min_confidence) ||
+					    ($face2->height() < $min_face_size)) {
 						continue;
 					}
 					$distance = dlib_vector_length($face1->descriptor, $face2->descriptor);
@@ -290,20 +295,23 @@ class CreateClustersTask extends FaceRecognitionBackgroundTask {
 				}
 			}
 		} else {
-			for ($i = 0, $face_count1 = count($faces); $i < $face_count1; $i++) {
+			$euclidean = new Euclidean();
+			$faces_count = count($faces);
+			for ($i = 0; $i < $faces_count; $i++) {
 				$face1 = $faces[$i];
-				if ($face1->confidence < $min_confidence) {
+				if (($face1->confidence < $min_confidence) ||
+				    ($face1->height() < $min_face_size)) {
 					$edges[] = array($i, $i);
 					continue;
 				}
-				for ($j = $i, $face_count2 = count($faces); $j < $face_count2; $j++) {
+				for ($j = $i; $j < $faces_count; $j++) {
 					$face2 = $faces[$j];
-					if ($face2->confidence < $min_confidence) {
+					if (($face2->confidence < $min_confidence) ||
+					    ($face2->height() < $min_face_size)) {
 						continue;
 					}
 					// todo: can't this distance be a method in $face1->distance($face2)?
 					$distance = $euclidean->distance($face1->descriptor, $face2->descriptor);
-
 					if ($distance < $sensitivity) {
 						$edges[] = array($i, $j);
 					}

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -194,6 +194,12 @@ class SettingsController extends Controller {
 					$this->settingsService->setNeedRecreateClusters(true, $user->getUID());
 				});
 				break;
+			case SettingsService::MINIMUM_FACE_SIZE_KEY:
+				$this->settingsService->setMinimumFaceSize($value);
+				$this->userManager->callForSeenUsers(function(IUser $user) {
+					$this->settingsService->setNeedRecreateClusters(true, $user->getUID());
+				});
+				break;
 			case SettingsService::SHOW_NOT_GROUPED_KEY:
 				$this->settingsService->setShowNotGrouped($value === 'true' ? true : false);
 				break;
@@ -229,6 +235,9 @@ class SettingsController extends Controller {
 				break;
 			case SettingsService::MINIMUM_CONFIDENCE_KEY:
 				$value = $this->settingsService->getMinimumConfidence();
+				break;
+			case SettingsService::MINIMUM_FACE_SIZE_KEY:
+				$value = $this->settingsService->getMinimumFaceSize();
 				break;
 			case SettingsService::ANALYSIS_IMAGE_AREA_KEY:
 				$value = $this->settingsService->getAnalysisImageArea();

--- a/lib/Db/FaceMapper.php
+++ b/lib/Db/FaceMapper.php
@@ -131,7 +131,7 @@ class FaceMapper extends QBMapper {
 
 	public function getFaces(string $userId, $model): array {
 		$qb = $this->db->getQueryBuilder();
-		$qb->select('f.id', 'f.person', 'f.bottom', 'f.top', 'f.confidence', 'f.descriptor')
+		$qb->select('f.id', 'f.person', 'f.left', 'f.right', 'f.top', 'f.bottom', 'f.confidence', 'f.descriptor')
 			->from($this->getTableName(), 'f')
 			->innerJoin('f', 'facerecog_images' ,'i', $qb->expr()->eq('f.image', 'i.id'))
 			->where($qb->expr()->eq('user', $qb->createParameter('user')))

--- a/lib/Db/FaceMapper.php
+++ b/lib/Db/FaceMapper.php
@@ -131,7 +131,7 @@ class FaceMapper extends QBMapper {
 
 	public function getFaces(string $userId, $model): array {
 		$qb = $this->db->getQueryBuilder();
-		$qb->select('f.id', 'f.person', 'f.confidence', 'f.descriptor')
+		$qb->select('f.id', 'f.person', 'f.bottom', 'f.top', 'f.confidence', 'f.descriptor')
 			->from($this->getTableName(), 'f')
 			->innerJoin('f', 'facerecog_images' ,'i', $qb->expr()->eq('f.image', 'i.id'))
 			->where($qb->expr()->eq('user', $qb->createParameter('user')))

--- a/lib/Helper/TempImage.php
+++ b/lib/Helper/TempImage.php
@@ -109,13 +109,9 @@ class TempImage extends Image {
 	 *
 	 */
 	private function prepareImage() {
-		try {
-			$this->loadFromFile($this->imagePath);
-		} catch (Exception $e) {
-			throw new \RuntimeException("Image is not valid, probably cannot be loaded");
-		}
-
+		$this->loadFromFile($this->imagePath);
 		$this->fixOrientation();
+
 		if (!$this->valid()) {
 			throw new \RuntimeException("Image is not valid, probably cannot be loaded");
 		}

--- a/lib/Helper/TempImage.php
+++ b/lib/Helper/TempImage.php
@@ -109,9 +109,13 @@ class TempImage extends Image {
 	 *
 	 */
 	private function prepareImage() {
-		$this->loadFromFile($this->imagePath);
-		$this->fixOrientation();
+		try {
+			$this->loadFromFile($this->imagePath);
+		} catch (Exception $e) {
+			throw new \RuntimeException("Image is not valid, probably cannot be loaded");
+		}
 
+		$this->fixOrientation();
 		if (!$this->valid()) {
 			throw new \RuntimeException("Image is not valid, probably cannot be loaded");
 		}

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -63,6 +63,12 @@ class SettingsService {
 	const DEFAULT_MINIMUM_CONFIDENCE = '0.99';
 	const MAXIMUM_MINIMUM_CONFIDENCE = '1.1';
 
+	/** Minimum face size used to try to clustring faces */
+	const MINIMUM_FACE_SIZE_KEY = 'min_face_size';
+	const MINIMUM_MINIMUM_FACE_SIZE = '0';
+	const DEFAULT_MINIMUM_FACE_SIZE = '125';
+	const MAXIMUM_MINIMUM_FACE_SIZE = '250';
+
 	/** Show single persons on clustes view */
 	const SHOW_NOT_GROUPED_KEY = 'show_not_grouped';
 	const DEFAULT_SHOW_NOT_GROUPED = 'false';
@@ -228,6 +234,14 @@ class SettingsService {
 
 	public function setMinimumConfidence($confidence) {
 		$this->config->setAppValue(Application::APP_NAME, self::MINIMUM_CONFIDENCE_KEY, $confidence);
+	}
+
+	public function getMinimumFaceSize(): int {
+		return intval($this->config->getAppValue(Application::APP_NAME, self::MINIMUM_FACE_SIZE_KEY, self::DEFAULT_MINIMUM_FACE_SIZE));
+	}
+
+	public function setMinimumFaceSize($face_size) {
+		$this->config->setAppValue(Application::APP_NAME, self::MINIMUM_FACE_SIZE_KEY, $face_size);
 	}
 
 	public function getShowNotGrouped(): bool {

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -56,6 +56,21 @@
 		</p>
 		<br>
 		<h3>
+			<?php p($l->t('Minimum face size'));?>
+		</h3>
+		<p class="settings-hint"><?php p($l->t('Very small faces may be discovered during analysis, however they can be very diffuse to compare reliably. The smaller faces will not be clustered, but you will still be able to identify them.'));?>
+			<a target="_blank" rel="noreferrer noopener" class="icon-info" title="<?php p($l->t('Open Documentation'));?>" href="https://github.com/matiasdelellis/facerecognition/wiki/Mininimum-face-size"></a>
+		</p>
+		<p class="settings-ranged">
+			<label for="min-face-range"><?php p($l->t('Small faces'));?></label>
+			<span><input type="range" id="min-face-range" min="0" max="250" value="125" step="1" class="ui-slider"></span>
+			<label for="min-face-range"><?php p($l->t('Big faces'));?></label>
+			<span id="min-face-value"class="span-highlighted">...</span>
+			<a id="restore-min-face" class="icon-align icon-history" style="display: none;" title="<?php p($l->t('Restore'));?>" href="#"></a>
+			<a id="save-min-face" class="icon-align icon-edit" style="display: none;" title="<?php p($l->t('Save'));?>" href="#"></a>
+		</p>
+		<br>
+		<h3>
 			<?php p($l->t('Additional settings'));?>
 		</h3>
 		<p>

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -58,7 +58,7 @@
 		<h3>
 			<?php p($l->t('Minimum face size'));?>
 		</h3>
-		<p class="settings-hint"><?php p($l->t('Very small faces may be discovered during analysis, however they can be very diffuse to compare reliably. The smaller faces will not be clustered, but you will still be able to identify them.'));?>
+		<p class="settings-hint"><?php p($l->t('Very small faces may be discovered during analysis, however they can be very diffuse to compare reliably. The smaller faces will not be clustered, but you can still see and name them individually.'));?>
 			<a target="_blank" rel="noreferrer noopener" class="icon-info" title="<?php p($l->t('Open Documentation'));?>" href="https://github.com/matiasdelellis/facerecognition/wiki/Mininimum-face-size"></a>
 		</p>
 		<p class="settings-ranged">


### PR DESCRIPTION
Now in my database, i have so many faces of just 30 pixels. Most of all, poor
quality WhatsApp photos, but since I increase them to 2Mpx to analyze, the
process finds an lot of that faces.

I like to see them, but nobody can believe that with 30px you can reliably
compare something. So I just don't group them.

As you can imagine, this is inspired by the last (super promising and failed :sweat_smile:) branch... 

Well, I read a lot of documentation, and the recognition model is indeed trained for 150px faces.
Anything smaller than that can be problematic, however the default value is set to 125. Just to have some margin..

However, it is worth noting that this value is taken from the real image.. So, if you have a 150 pixel face, in a very large image, that eventually shrinks during analysis, the descriptor is obtained from an image of less than 150px, which will not be reliable. :disappointed: 

To know if it is reliable, we should save the ratio and calculate the size used on analysis. But it is out of this PR.
Also, we could crop the image over the rectangle of the face and analyze the original, but I would rather avoid it.  Remember that? https://github.com/matiasdelellis/facerecognition/pull/142 :see_no_evil: 

Well, as I said in the commit, a 30px face is not reliable, and at least I avoid these cases.. 
