### PR TITLE
Misc fixes

### DIFF
--- a/lib/BackgroundJob/Tasks/ImageProcessingTask.php
+++ b/lib/BackgroundJob/Tasks/ImageProcessingTask.php
@@ -252,9 +252,9 @@ class ImageProcessingTask extends FaceRecognitionBackgroundTask {
 	 */
 	private function getNormalizedFace(array $rawFace, float $ratio): array {
 		$face = [];
-		$face['left'] = intval(round(max($rawFace['left'], 0)*$ratio));
+		$face['left'] = intval(round($rawFace['left']*$ratio));
 		$face['right'] = intval(round($rawFace['right']*$ratio));
-		$face['top'] = intval(round(max($rawFace['top'], 0)*$ratio));
+		$face['top'] = intval(round($rawFace['top']*$ratio));
 		$face['bottom'] = intval(round($rawFace['bottom']*$ratio));
 		$face['detection_confidence'] = $rawFace['detection_confidence'];
 		return $face;

--- a/lib/Db/Face.php
+++ b/lib/Db/Face.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Copyright (c) 2017, Matias De lellis <mati86dl@gmail.com>
+ * @copyright Copyright (c) 2017-2020 Matias De lellis <mati86dl@gmail.com>
  * @copyright Copyright (c) 2018, Branko Kokanovic <branko@kokanovic.org>
  *
  * @author Branko Kokanovic <branko@kokanovic.org>
@@ -127,9 +127,9 @@ class Face extends Entity implements JsonSerializable {
 		$face = new Face();
 		$face->setImage($image);
 		$face->setPerson(null);
-		$face->setLeft(max($faceFromModel["left"], 0));
+		$face->setLeft($faceFromModel["left"]);
 		$face->setRight($faceFromModel["right"]);
-		$face->setTop(max($faceFromModel["top"], 0));
+		$face->setTop($faceFromModel["top"]);
 		$face->setBottom($faceFromModel["bottom"]);
 		$face->setConfidence($faceFromModel["detection_confidence"]);
 		$face->setLandmarks("[]");

--- a/lib/Model/DlibHogModel/DlibHogModel.php
+++ b/lib/Model/DlibHogModel/DlibHogModel.php
@@ -197,7 +197,7 @@ class DlibHogModel implements IModel {
 	public function detectFaces(string $imagePath): array {
 		$faces_detected = dlib_face_detection($imagePath);
 		// To improve clustering a confidence value is needed, which this model does not provide
-		return array_map (function (array $face) { $face['detection_confidence'] = 1.0; return $face; }, $faces_detected);
+		return array_map (function (array $face) { $face['detection_confidence'] = 1.1; return $face; }, $faces_detected);
 	}
 
 	public function detectLandmarks(string $imagePath, array $rect): array {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -267,7 +267,7 @@ class SettingsService {
 		$minFaceSize = intval($this->config->getAppValue(Application::APP_NAME, self::MINIMUM_FACE_SIZE_KEY, self::DEFAULT_MINIMUM_FACE_SIZE));
 		$minFaceSize = max(self::MINIMUM_MINIMUM_FACE_SIZE, $minFaceSize);
 		$minFaceSize = min($minFaceSize, self::MAXIMUM_MINIMUM_FACE_SIZE);
-		return $minFaceSize;
+		return intval($minFaceSize);
 	}
 
 	public function getMaximumImageArea(): int {


### PR DESCRIPTION
* Fix must return integer instead string.. This commit I am 99% sure I uploaded yesterday. Weird .. haha
* Just save the normalized faces rect, allowing negatives.

In any case it should be considered when cut the face previews, but is important
to have the most original information possible.

On the other hand, we never consider the pixels that exceed the image, and
everything works correctly with these faces.

