### PR TITLE
allow max-nc-version 21 and max-php-version 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,21 +15,19 @@ php:
   
 env:
   global:
-    - CORE_BRANCH=stable18
+    - CORE_BRANCH=stable20
     - APP_NAME=facerecognition
   matrix:
     - DB=mysql
     - DB=pgsql
     - DB=sqlite
-    - DB=mysql CORE_BRANCH=stable19
-    - DB=pgsql CORE_BRANCH=stable19
-    - DB=sqlite CORE_BRANCH=stable19
-    - DB=mysql CORE_BRANCH=stable20
-    - DB=pgsql CORE_BRANCH=stable20
-    - DB=sqlite CORE_BRANCH=stable20
     - DB=mysql CORE_BRANCH=stable21
     - DB=pgsql CORE_BRANCH=stable21
     - DB=sqlite CORE_BRANCH=stable21
+jobs:
+  exclude:
+    - php: 7.2
+      env: CORE_BRANCH=stable21
 
 before_install:
   # Installing pdlib (install dlib from repo and compile pdlib on top of it)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ services:
 php:
   - 7.2
   - 7.3
-
+  - 7.4
+  
 env:
   global:
     - CORE_BRANCH=stable18
@@ -26,7 +27,9 @@ env:
     - DB=mysql CORE_BRANCH=stable20
     - DB=pgsql CORE_BRANCH=stable20
     - DB=sqlite CORE_BRANCH=stable20
-
+    - DB=mysql CORE_BRANCH=stable21
+    - DB=pgsql CORE_BRANCH=stable21
+    - DB=sqlite CORE_BRANCH=stable21
 
 before_install:
   # Installing pdlib (install dlib from repo and compile pdlib on top of it)
@@ -67,4 +70,3 @@ script:
 
 after_failure:
   - cat ../../data/nextcloud.log
-

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,10 +33,10 @@
 	<screenshot>https://matiasdelellis.github.io/img/facerecognition/facerecognition-photos-integration.jpeg</screenshot>
 	<screenshot>https://matiasdelellis.github.io/img/facerecognition/facerecognition-assign-initial-name.jpeg</screenshot>
 	<dependencies>
-		<php min-version="7.2"/>
+		<php min-version="7.2" max-version="7.4" />
 		<lib>pdlib</lib>
 		<lib>bz2</lib>
-		<nextcloud min-version="18" max-version="20"/>
+		<nextcloud min-version="18" max-version="21"/>
 	</dependencies>
 	<repair-steps>
 		<uninstall>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -36,7 +36,7 @@
 		<php min-version="7.2" max-version="7.4" />
 		<lib>pdlib</lib>
 		<lib>bz2</lib>
-		<nextcloud min-version="18" max-version="21"/>
+		<nextcloud min-version="20" max-version="21"/>
 	</dependencies>
 	<repair-steps>
 		<uninstall>

--- a/tests/unit/LockUnlockTaskTest.php
+++ b/tests/unit/LockUnlockTaskTest.php
@@ -46,10 +46,16 @@ class LockTaskTest extends TestCase {
 	 * {@inheritDoc}
 	 */
 	public function setUp(): void {
-		$userManager = $this->createMock(IUserManager::class);
-		$config = $this->createMock(IConfig::class);
+		$userManager = $this->getMockBuilder(IUserManager::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$config = $this->getMockBuilder(IConfig::class)
+			->disableOriginalConstructor()
+			->getMock();
 		$this->context = new FaceRecognitionContext($userManager, $config);
-		$logger = $this->createMock(ILogger::class);
+		$logger = $this->getMockBuilder(ILogger::class)
+			->disableOriginalConstructor()
+			->getMock();
 		$this->context->logger = new FaceRecognitionLogger($logger);
 	}
 


### PR DESCRIPTION
Since it was by several users confirmed in #429 that the app works on NC21 with PHP 7.4, I've just took the opportunity to add those values.
BTW: afaik, since a while the appstore should actually respect max versions for php before updating/installing the app.

Signed-off-by: szaimen <szaimen@e.mail.de>