### PR TITLE
Rename identifiers in OCS Api controller to match what Nextcloud expects

### DIFF
--- a/lib/Controller/OcsApiController.php
+++ b/lib/Controller/OcsApiController.php
@@ -44,7 +44,7 @@ use OCA\FaceRecognition\Db\PersonMapper;
 use OCA\FaceRecognition\Service\SettingsService;
 use OCA\FaceRecognition\Service\UrlService;
 
-class OCSApiController extends OCSController {
+class OcsApiController extends OCSController {
 
 	/** @var FaceMapper */
 	private $faceMapper;
@@ -103,7 +103,7 @@ class OCSApiController extends OCSController {
 	 *
 	 * @return DataResponse
 	 */
-	public function getPersons(): DataResponse {
+	public function getPersonsV1(): DataResponse {
 		$userEnabled = $this->settingsService->getUserEnabled($this->userId);
 
 		$resp = array();


### PR DESCRIPTION
Right now calling any of the OCS APIs in v0.9.10 will throw a OCP\AppFramework\QueryException on the server, because the file, class and method are not named correctly. This PR fixed them such that the router can correct instantiate the class and invoke the correct method.