### PR TITLE
added options to command face:sync-albums

### DIFF
--- a/lib/Command/SyncAlbumsCommand.php
+++ b/lib/Command/SyncAlbumsCommand.php
@@ -176,6 +176,10 @@ class SyncAlbumsCommand extends Command {
 				}
 				else if ($mode === "Album-combined") {
 					$personList = explode(",", $person_name); 
+					if ( count($personList) < 2 ){
+						$output->writeln("Note parameter mode <$mode> requires at least two persons");
+						return 1;
+					}
 					$this->photoAlbums->syncUserPersonNamesCombinedAlbum($userId,$personList,$output);
 				}
 				else {

--- a/lib/Command/SyncAlbumsCommand.php
+++ b/lib/Command/SyncAlbumsCommand.php
@@ -34,6 +34,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 
 use OCA\FaceRecognition\Helper\PhotoAlbums;
+use OCA\FaceRecognition\Db\PersonMapper;
 
 use OCA\FaceRecognition\Service\SettingsService;
 
@@ -41,6 +42,9 @@ class SyncAlbumsCommand extends Command {
 
 	/** @var IUserManager */
 	protected $userManager;
+
+        /** @var PersonMapper Person mapper*/
+	private $personMapper;
 
 	/** @var IAppManager */
 	private $appManager;
@@ -53,11 +57,13 @@ class SyncAlbumsCommand extends Command {
 
 	/**
 	 * @param IUserManager $userManager
+	 * @param PersonMapper $personMapper
 	 * @param PhotoAlbums $photoAlbums
 	 * @param SettingsService $settingsService
 	 * @param IAppManager $appManager
 	 */
 	public function __construct(IUserManager    $userManager,
+	                            PersonMapper    $personMapper,
 	                            IAppManager     $appManager,
 	                            PhotoAlbums     $photoAlbums,
 	                            SettingsService $settingsService)
@@ -65,6 +71,7 @@ class SyncAlbumsCommand extends Command {
 		parent::__construct();
 
 		$this->appManager      = $appManager;
+		$this->personMapper    = $personMapper;
 		$this->userManager     = $userManager;
 		$this->photoAlbums     = $photoAlbums;
 		$this->settingsService = $settingsService;
@@ -83,6 +90,24 @@ class SyncAlbumsCommand extends Command {
 				InputOption::VALUE_REQUIRED,
 				'Sync albums for a given user only. If not given, sync albums for all users.',
 				null
+			)->addOption(
+				'list_person',
+				'l',
+				InputOption::VALUE_NONE,
+				'List all persons defined for the given user_id.',
+				null
+			)->addOption(
+				'person_name',
+				'p',
+				InputOption::VALUE_REQUIRED,
+				'Sync albums for a given user and person name(s) (separate using comma). If not used, sync albums for all persons defined by the user.',
+				null
+			)->addOption(
+				'mode',
+				'm',
+				InputOption::VALUE_REQUIRED,
+				'Album creation mode. Use "Album-per-person" to create one album for each given person via person_name parameter. Use "Album-combined" to create one album for all person names given via person_name parameter.',
+				'Album-per-person'
 			);
 	}
 
@@ -99,6 +124,9 @@ class SyncAlbumsCommand extends Command {
 
 		$users = array();
 		$userId = $input->getOption('user_id');
+		$personNames = array();
+		$person_name = $input->getOption('person_name');
+		$mode = $input->getOption('mode');
 		if (!is_null($userId)) {
 			if ($this->userManager->get($userId) === null) {
 				$output->writeln("User with id <$userId> in unknown.");
@@ -113,11 +141,53 @@ class SyncAlbumsCommand extends Command {
 				$users[] = $iUser->getUID();
 			});
 		}
+		if ($input->getOption('list_person')){
+			if (is_null($userId)) {
+			$output->writeln("List option requires option user_id!");
+				return 1;
+			}else{
+				$output->writeln("List of defined persons for the user <$userId> :");
+				$modelId = $this->settingsService->getCurrentFaceModel();
+				$distintNames = $this->personMapper->findDistinctNames($userId, $modelId);
+				foreach ($distintNames as $key=>$distintName) {
+					if ($key > 0 ){
+						$output->write(", ");
+					}
+					$output->write($distintName->getName());
+				}
+				$output->writeln("");
+				$output->writeln("Done.");
+			}
+			return 0;
+		}
 
 		foreach ($users as $user) {
-			$output->write("Synchronizing albums for the user <$userId>. ");
-			$this->photoAlbums->syncUser($userId);
-			$output->writeln("Done.");
+			if (!is_null($person_name)) {
+				if (is_null($userId)) {
+					$output->writeln("Person_name option requires option user_id!");
+					return 1;
+				}
+				$output->writeln("Synchronizing albums for the user <$userId> and person_name <$person_name> using mode <$mode>. ");
+				if ($mode === "Album-per-person") {
+					$personList = explode(",", $person_name);
+					foreach ($personList as $person) {
+						$this->photoAlbums->syncUserPersonNamesSelected($userId,$person,$output);
+					}
+				}
+				else if ($mode === "Album-combined") {
+					$personList = explode(",", $person_name); 
+					$this->photoAlbums->syncUserPersonNamesCombinedAlbum($userId,$personList,$output);
+				}
+				else {
+					$output->writeln("Error: invalid value for parameter mode <$mode>. ");
+					return 1;
+				}
+				$output->writeln("Done.");
+			}else{
+				$output->write("Synchronizing albums for the user <$userId>. ");
+				$this->photoAlbums->syncUser($userId);
+				$output->writeln("Done.");
+			}
 		}
 
 		return 0;

--- a/lib/Db/PersonMapper.php
+++ b/lib/Db/PersonMapper.php
@@ -153,6 +153,27 @@ class PersonMapper extends QBMapper {
 	}
 
 	/**
+	 * @param string $userId ID of the user
+	 *
+	 * @return Person[]
+	 */
+	public function findDistinctNamesSelected(string $userId, int $modelId, $faceNames): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->selectDistinct('name')
+			->from($this->getTableName(), 'p')
+			->innerJoin('p', 'facerecog_faces' , 'f', $qb->expr()->eq('f.person', 'p.id'))
+			->innerJoin('f', 'facerecog_images' ,'i', $qb->expr()->eq('f.image', 'i.id'))
+			->where($qb->expr()->eq('i.user', $qb->createParameter('user_id')))
+			->andWhere($qb->expr()->eq('i.model', $qb->createParameter('model_id')))
+			->andwhere($qb->expr()->isNotNull('p.name'))
+			->andWhere($qb->expr()->eq('p.name', $qb->createParameter('faceNames')))
+			->setParameter('user_id', $userId)
+			->setParameter('model_id', $modelId)
+			->setParameter('faceNames', $faceNames);
+		return $this->findEntities($qb);
+	}
+
+	/**
 	 * Search Person by name
 	 *
 	 * @param int|null $offset


### PR DESCRIPTION
Hello,
I like facerecognition and its sync-album command. Because I don't want/need to create albums for all persons I added an option to create only albums for selected persons. I also like to create albums with photos containing several persons therefore I added a mode option "Album-per-person" vs "Album-combined". Also added a list persons option to allow to list persons from command line.

Options added to command face:sync-albums:
    -l, --list_persons : List all person defined for a given user_id
    -p, --person_name=PERSON_NAME : Sync albums for a given user and person name(s) (separeted using comma). If not used, sync all persons defined by the user
    -m, --mode=MODE : Album creation mode. Use "Album-per-person" to create one album for each given person via person_name parameter. Use "Album-combined" to create one album for all person names given via person_name parameter. [default: "Album-per-user"]

I hope this is meaningful/helpful also for others.  Of course open for feedback / discussion. 

Cheers,
Marcel