### PR TITLE
Force analyze files

### DIFF
--- a/lib/BackgroundJob/BackgroundService.php
+++ b/lib/BackgroundJob/BackgroundService.php
@@ -80,10 +80,11 @@ class BackgroundService {
 	 * @param IUser|null $user ID of user to execute background operations for
 	 * @param int|null $maxImageArea Max image area (in pixels^2) to be fed to neural network when doing face detection
 	 * @param string $runMode The command execution mode
+	 * @param array $forceAnalyzeFiles An array containing the names of files that shall be analyzed
 	 *
 	 * @return void
 	 */
-	public function execute(int $timeout, bool $verbose, IUser $user = null, int $maxImageArea = null, string $runMode) {
+	public function execute(int $timeout, bool $verbose, IUser $user = null, int $maxImageArea = null, string $runMode, $forceAnalyzeFiles = []) {
 		// Put to context all the stuff we are figuring only now
 		//
 		$this->context->user = $user;
@@ -91,6 +92,7 @@ class BackgroundService {
 		$this->context->setRunningThroughCommand();
 		$this->context->propertyBag['max_image_area'] = $maxImageArea;
 		$this->context->propertyBag['run_mode'] = $runMode;
+		$this->context->propertyBag['force_analyze_files'] = $forceAnalyzeFiles;
 
 		// Here we are defining all the tasks that will get executed.
 		//

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -113,7 +113,11 @@ class FileService {
 	 * @return Node | null
 	 */
 	public function getFileByPath($fullpath, $userId = null): ?Node {
-		$file = $this->rootFolder->getUserFolder($this->userId ?? $userId)->get($fullpath);
+		try {		
+			$file = $this->rootFolder->getUserFolder($this->userId ?? $userId)->get($fullpath);
+		} catch(NotFoundException $e) {
+			$file = null;
+		}			
 		return $file;
 	}
 


### PR DESCRIPTION
Add an option (--force_analyze_files) that enablee the user to explicitly (re-)analyze specific files.
    
    - The  --force_analyze_files option allows the user to specify files that they want to analyze.
    - The  --force_analyze_files (or -f) option can be used multiple times to analyze more than one file.
    - The images must be given relative to the data/USER_ID/files folder and thus the --user_id option is required.
    - The  --force_analyze_files option does not work together with sync-mode or cluster-mode.
    - If no mode is specified by the user, defer-mode is enabled for a better user experience.
    - Files that are specified using the  --force_analyze_files option are put at the front of the analysis queue and thus are analyzed first.