### PR TITLE
Multiple external model instances

### DIFF
--- a/lib/BackgroundJob/BackgroundService.php
+++ b/lib/BackgroundJob/BackgroundService.php
@@ -37,7 +37,11 @@ use OCA\FaceRecognition\BackgroundJob\Tasks\CreateClustersTask;
 use OCA\FaceRecognition\BackgroundJob\Tasks\DisabledUserRemovalTask;
 use OCA\FaceRecognition\BackgroundJob\Tasks\EnumerateImagesMissingFacesTask;
 use OCA\FaceRecognition\BackgroundJob\Tasks\ImageProcessingTask;
+use OCA\FaceRecognition\BackgroundJob\Tasks\ImageProcessingWithMultipleExternalModelInstancesTask;
 use OCA\FaceRecognition\BackgroundJob\Tasks\StaleImagesRemovalTask;
+
+use OCA\FaceRecognition\Model\ExternalModel\ExternalModel;
+use OCA\FaceRecognition\Service\SettingsService;
 
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -58,9 +62,16 @@ class BackgroundService {
 	/** @var FaceRecognitionContext $context */
 	private $context;
 
-	public function __construct(Application $application, FaceRecognitionContext $context) {
+	/** @var SettingsService */
+	protected $settingsService;	
+
+	public function __construct(Application $application, 
+								SettingsService  $settingsService,
+								FaceRecognitionContext $context) {
 		$this->application = $application;
 		$this->context = $context;
+
+		$this->settingsService    = $settingsService;
 	}
 
 	public function setLogger(OutputInterface $logger): void {
@@ -70,6 +81,13 @@ class BackgroundService {
 		}
 
 		$this->context->logger = new FaceRecognitionLogger($logger);
+	}
+
+	private function getImageProcessingTask(): string {
+		if($this->settingsService->getCurrentFaceModel() == ExternalModel::FACE_MODEL_ID and $this->settingsService->getExternalModelNumberOfInstances() > 1) {
+			return ImageProcessingWithMultipleExternalModelInstancesTask::class;
+		}
+		return ImageProcessingTask::class; 
 	}
 
 	/**
@@ -108,7 +126,7 @@ class BackgroundService {
 				break;
 			case 'analyze-mode':
 				$task_classes[] = EnumerateImagesMissingFacesTask::class;
-				$task_classes[] = ImageProcessingTask::class;
+				$task_classes[] = $this->getImageProcessingTask();
 				break;
 			case 'cluster-mode':
 				$task_classes[] = CreateClustersTask::class;
@@ -118,7 +136,7 @@ class BackgroundService {
 				$task_classes[] = StaleImagesRemovalTask::class;
 				$task_classes[] = AddMissingImagesTask::class;
 				$task_classes[] = EnumerateImagesMissingFacesTask::class;
-				$task_classes[] = ImageProcessingTask::class;
+				$task_classes[] = $this->getImageProcessingTask();
 				$task_classes[] = CreateClustersTask::class;
 				break;
 			case 'default-mode':
@@ -128,7 +146,7 @@ class BackgroundService {
 				$task_classes[] = CreateClustersTask::class;
 				$task_classes[] = AddMissingImagesTask::class;
 				$task_classes[] = EnumerateImagesMissingFacesTask::class;
-				$task_classes[] = ImageProcessingTask::class;
+				$task_classes[] = $this->getImageProcessingTask();
 				break;
 		}
 

--- a/lib/BackgroundJob/BackgroundService.php
+++ b/lib/BackgroundJob/BackgroundService.php
@@ -151,6 +151,7 @@ class BackgroundService {
 						$currentTime = time();
 						if (($timeout > 0) && ($currentTime - $startTime > $timeout)) {
 							$this->context->logger->logInfo("Time out. Quitting...");
+							$task->cleanUpOnTimeout();
 							return;
 						}
 

--- a/lib/BackgroundJob/FaceRecognitionBackgroundTask.php
+++ b/lib/BackgroundJob/FaceRecognitionBackgroundTask.php
@@ -58,6 +58,14 @@ abstract class FaceRecognitionBackgroundTask implements IFaceRecognitionBackgrou
 	}
 
 	/**
+	 * Clean up temporary data and files if needed.
+	 * This method will be called when the task is termindated prematurely due to timeout.
+	 */
+	public function cleanUpOnTimeout(): void {
+		$this->logDebug(sprintf("The %s has been terminated prematurely. Cleaning up.", end(explode('\\', get_class($this)))));
+	}
+
+	/**
 	 * Sets context for a given task, so it can be accessed in task (without a need to dragging it around from execute() method).
 	 * Currently public, because of tests (ideally it should be protected).
 	 *

--- a/lib/BackgroundJob/FaceRecognitionBackgroundTask.php
+++ b/lib/BackgroundJob/FaceRecognitionBackgroundTask.php
@@ -62,7 +62,8 @@ abstract class FaceRecognitionBackgroundTask implements IFaceRecognitionBackgrou
 	 * This method will be called when the task is termindated prematurely due to timeout.
 	 */
 	public function cleanUpOnTimeout(): void {
-		$this->logDebug(sprintf("The %s has been terminated prematurely. Cleaning up.", end(explode('\\', get_class($this)))));
+		$classname = explode('\\', get_class($this));
+		$this->logDebug(sprintf("The %s has been terminated prematurely. Cleaning up.", end($classname)));
 	}
 
 	/**

--- a/lib/BackgroundJob/FaceRecognitionContext.php
+++ b/lib/BackgroundJob/FaceRecognitionContext.php
@@ -26,6 +26,7 @@ namespace OCA\FaceRecognition\BackgroundJob;
 use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserManager;
+use \Psr\Log\LoggerInterface;
 
 use OCA\FaceRecognition\BackgroundJob\FaceRecognitionLogger;
 
@@ -43,6 +44,12 @@ class FaceRecognitionContext {
 	/** @var FaceRecognitionLogger */
 	public $logger;
 
+	/** @var LoggerInterface Reference to Nextcloud logger instance. This logger can be used to create messages that are shown in the Nextcloud log. See https://docs.nextcloud.com/server/28/developer_manual/basics/logging.html. */
+	public $ncLogger;
+
+	/** @var string Name of this application */
+    public $appName;	
+
 	/** @var IUser|null */
 	public $user;
 
@@ -55,8 +62,12 @@ class FaceRecognitionContext {
 	/** @var bool True if we are running from command, false if we are running as background job */
 	private $isRunningThroughCommand;
 
-	public function __construct(IUserManager $userManager,
-	                            IConfig      $config) {
+	public function __construct(IUserManager 	$userManager,
+								LoggerInterface $ncLogger, 
+								string 	     	$appName,	
+	                            IConfig      	$config) {
+		$this->ncLogger = $ncLogger;
+		$this->appName = $appName;
 		$this->userManager = $userManager;
 		$this->config = $config;
 		$this->isRunningThroughCommand = false;

--- a/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
+++ b/lib/BackgroundJob/Tasks/CheckRequirementsTask.php
@@ -155,6 +155,10 @@ class CheckRequirementsTask extends FaceRecognitionBackgroundTask {
 		}
 
 		try {
+			$this->logDebug("Opening model...");
+			if($model->getId() == 5) {
+				$this->logDebug(" --> using the external model. Note: this operation may take a while if the external model is still busy with a previous analysis that was terminated prematurely due to a timeout.");
+			}
 			$model->open();
 		} catch (UnavailableException $e) {
 			$this->logInfo("Error accessing the model to get required information: " . $e->getMessage());

--- a/lib/BackgroundJob/Tasks/ImageProcessingWithMultipleExternalModelInstancesTask.php
+++ b/lib/BackgroundJob/Tasks/ImageProcessingWithMultipleExternalModelInstancesTask.php
@@ -1,0 +1,707 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017-2020 Matias De lellis <mati86dl@gmail.com>
+ * @copyright Copyright (c) 2018, Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @author Branko Kokanovic <branko@kokanovic.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\FaceRecognition\BackgroundJob\Tasks;
+
+use CurlHandle;
+use OCP\Image as OCP_Image;
+
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Lock\ILockingProvider;
+use OCP\IUser;
+
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionBackgroundTask;
+use OCA\FaceRecognition\BackgroundJob\FaceRecognitionContext;
+
+use OCA\FaceRecognition\Db\Face;
+use OCA\FaceRecognition\Db\Image;
+use OCA\FaceRecognition\Db\ImageMapper;
+
+use OCA\FaceRecognition\Helper\TempImage;
+use OCA\FaceRecognition\Model\IModel;
+use OCA\FaceRecognition\Model\ModelManager;
+use OCA\FaceRecognition\Model\ExternalModel\ExternalModel;
+
+use OCA\FaceRecognition\Service\FileService;
+use OCA\FaceRecognition\Service\SettingsService;
+
+/**
+ * Taks that get all images that are still not processed and processes them.
+ * Processing image means that each image is prepared, faces extracted form it,
+ * and for each found face - face descriptor is extracted.
+ */
+class ImageProcessingWithMultipleExternalModelInstancesTask extends FaceRecognitionBackgroundTask {
+
+	/** @var ImageMapper Image mapper*/
+	protected $imageMapper;
+
+	/** @var FileService */
+	protected $fileService;
+
+	/** @var SettingsService */
+	protected $settingsService;
+
+	/** @var ModelManager $modelManager */
+	protected $modelManager;
+
+	/** @var ILockingProvider $lockingProvider */
+	protected ILockingProvider $lockingProvider;
+
+	/** @var IModel $model */
+	private $model;
+
+	/** @var int|null $maxImageAreaCached Maximum image area (cached, so it is not recalculated for each image) */
+	private $maxImageAreaCached;
+
+	/** @var Array $preparedTasks Set of instances for which a task has been prepared */
+	private $preparedTasks;
+
+	/** @var Array $scheduledTasks Set of instances which are currently busy with a face recognition task */
+	private $scheduledTasks;
+
+	/** @var \CurlHandle[] $curlHandles All cURL handles */
+	private $curlHandles;
+
+	/** @var \CurlMultiHandle $curlMultiHandle The cURL multi handle */
+	private $curlMultiHandle;
+
+	/** @var  */
+	private $modelUrl;
+	private $modelApiKey;
+	private $modelConsecutivePorts;
+
+
+	/**
+	 * @param ImageMapper $imageMapper Image mapper
+	 * @param FileService $fileService
+	 * @param SettingsService $settingsService
+	 * @param ModelManager $modelManager Model manager
+	 * @param ILockingProvider $lockingProvider
+	 */
+	public function __construct(ImageMapper      $imageMapper,
+	                            FileService      $fileService,
+	                            SettingsService  $settingsService,
+	                            ModelManager     $modelManager,
+	                            ILockingProvider $lockingProvider)
+	{
+		parent::__construct();
+
+		$this->imageMapper        = $imageMapper;
+		$this->fileService        = $fileService;
+		$this->settingsService    = $settingsService;
+		$this->modelManager       = $modelManager;
+		$this->lockingProvider    = $lockingProvider;
+
+		$this->model              = null;
+		$this->maxImageAreaCached = null;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function description() {
+		return "Process all images to extract faces using multiple instances of the external model";
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function cleanUpOnTimeout(): void {
+		parent::cleanUpOnTimeout();
+
+		// TODO: Add an option and the required code to wait for all running analysis tasks to finish and save the results of those analyses.
+		// Note: The current behavior is OK because the task will quite without much delay after timeout. 
+		// 		 Waiting for the currently running analyses to finish woul dintroduce a significant extra delay during cleanup (depending on the speed of the external model).
+		//		 This delay in turn might result in the task still running when the next cron job is started, and thus, missing the next execution window.
+		//		 --> The user must account for this potential extra delay by shortening the timeout appropriately.
+		//		 --> There should be an option that needs to be enabled explicitly if the running tasks should be finished during cleanup.
+
+		// Clean up running tasks
+		foreach($this->scheduledTasks as $task) {
+			if(isset($task["curlHandle"])) {
+				curl_multi_remove_handle($this->curlMultiHandle, $task["curlHandle"]);
+			}
+			if(isset($task["tempImage"])) {
+				$task["tempImage"]->clean();
+			}
+			if(isset($task["lockKey"])) {
+				$this->lockingProvider->releaseLock($task["lockKey"], $task["lockType"]);
+			}
+		}
+
+		// Clean up prepared tasks
+		foreach($this->preparedTasks as $task) {
+			if(isset($task["tempImage"])) {
+				$task["tempImage"]->clean();
+			}
+			if(isset($task["lockKey"])) {
+				$this->lockingProvider->releaseLock($task["lockKey"], $task["lockType"]);
+			}
+		}
+
+		// Close cURL handles
+		foreach($this->curlHandles as $ch) {
+			curl_close($ch);
+		}
+
+		// Close cURL multi-handle
+		curl_multi_close($this->curlMultiHandle);		
+
+		// If there are temporary files from external files, they must also be cleaned.
+		$this->fileService->clean();
+
+	}
+
+
+	/**
+	 * Copied from ExternalModel::detectFaces, special modification of CURLOPT_URL
+	 */
+	private function prepDetectFacesRequest(\CurlHandle $ch, string $imagePath, int $port = 0) {
+		if ($ch === false) {
+			throw new \Exception('Curl error: unable to initialize curl');
+		}
+		
+		$cFile = curl_file_create($imagePath);
+		$post = array('file'=> $cFile);
+		
+		if($port > 0) {
+			curl_setopt($ch, CURLOPT_URL, preg_replace('/:\d+$/', ":$port", $this->modelUrl) . '/detect');
+		} else {
+			curl_setopt($ch, CURLOPT_URL, $this->modelUrl . '/detect');
+		}
+		curl_setopt($ch, CURLOPT_POST, true);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $post);
+		curl_setopt($ch, CURLOPT_HTTPHEADER, ['x-api-key: ' . $this->modelApiKey]);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);		
+	}
+
+	/**
+	 * Copied from ExternalModel::detectFaces
+	 */
+	public function evalDetectFacesResponse($response): array {
+		if (is_bool($response) or is_null($response)) {
+			throw new \Exception('Invalid response: ' . var_export($response, true));
+		}
+
+		$jsonResponse = json_decode($response, true);
+
+		if (!is_array($jsonResponse))
+			return [];
+
+		if ($jsonResponse['faces-count'] == 0)
+			return [];
+
+		return $jsonResponse['faces'];
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function execute(FaceRecognitionContext $context) {
+		$this->setContext($context);
+
+		$this->logInfo('NOTE: Starting face recognition. If you experience random crashes after this point, please look FAQ at https://github.com/matiasdelellis/facerecognition/wiki/FAQ');
+
+		// Get current model.
+		$this->model = $this->modelManager->getCurrentModel();
+
+		// Open model.
+		$this->model->open();
+
+		// occ config:system:set facerecognition.external_model_number_of_instances --value 8
+
+		if(!($this->model->getId() == ExternalModel::FACE_MODEL_ID and $this->settingsService->getExternalModelNumberOfInstances() > 1)) {
+			throw new \RuntimeException("The ImageProcessingWithMultipleExternalModelInstancesTask requires that the external model is selected and that the number of external instances is greater than one.");
+		}
+			
+		/*************************************************************************************************************************
+		 * If the EXTERNAL MODEL is set and more than 2 instances are configured to be used, then we can parallelize face analysis.
+		 */
+
+		$this->modelUrl = $this->settingsService->getExternalModelUrl();
+		$this->modelApiKey = $this->settingsService->getExternalModelApiKey();
+
+		$nInstances = $this->settingsService->getExternalModelNumberOfInstances();
+		$this->logInfo("NOTE: Using the EXTERNAL MODEL for face recognition.");
+		if($nInstances > 1) {
+			$this->logInfo("NOTE: Using $nInstances instances of the external model in parallel.");
+		}
+
+		// "free" instances are model instances without a prepared task.
+		// "prepared" instances are model instances for which a task has been prepared
+		// free / prepared is irrespective of whether the instance is idle or running
+		$freeInstances = range(0, $nInstances-1);
+		$preparedInstances = [];
+		$instancePrepared = array_fill(0, $nInstances, false);
+		// "idle" instances are model instances without assigned analysis request.
+		$idleInstances = range(0, $nInstances-1);
+		$activeInstances = [];
+		$instanceActive =  array_fill(0, $nInstances, false); 
+		
+		$basePort = 8080;
+		$matches = [];
+		if(preg_match("/:(\d+)$/", $this->modelUrl, $matches)) {
+			$basePort = $matches[1];
+		} else {
+			$basePort = $this->settingsService->getExternalModelInstanceDefaultPort();
+		}
+		$this->modelConsecutivePorts = $this->settingsService->getExternalModelInstancesHaveConsecutivePorts();
+		if($this->modelConsecutivePorts) {
+			for($i = 0; $i < $nInstances; $i++) {
+				$this->logDebug("- Instance $i: " . preg_replace('/:\d+$/', ":" . ($basePort+$i), $this->modelUrl));
+			}
+		}
+
+		// Initialize cURL handles
+		$nCurlHandles = 2 * $nInstances;
+		$chs = []; // curl handles
+		$this->curlHandles = $chs;
+		$unusedCurlHandles = range(0, $nCurlHandles-1);
+		try {
+			for($i = 0; $i < $nCurlHandles; $i++) {
+				$ch = curl_init();
+				if ($ch === false) {
+					throw new \Exception('Curl error: unable to initialize curl');
+				}
+				$chs[$i] = $ch;
+			}
+
+		} catch (\Exception $e) {
+			$this->logInfo('Faces found: 0. Image will be skipped because of the following error: ' . $e->getMessage());
+			$this->logDebug((string) $e);
+
+			for($i=0; $i < sizeof($chs); $i++) {
+				curl_close($chs[$i]);
+			}
+
+			return false;
+		}
+
+		// Create the cURL multi-handle
+		$mh = curl_multi_init();
+		$this->curlMultiHandle = $mh;
+
+
+		$this->preparedTasks = [];
+		$this->scheduledTasks = [];
+
+
+		// Do the actual image recognition task
+		$context = $this->context;
+		$images = $context->propertyBag['images'];
+		
+		do {
+
+			yield;
+
+			/**====================================================================================================
+			 * Prepare task
+			 */
+
+			// Check if we need to prepare an image for analysis
+			if(count($freeInstances) > 0) {
+
+				// Get the current element from the beginning of the array
+				$image = current($images);
+
+				// Check if there are still elements in $images
+				if ($image) {
+
+					// Move the array pointer to the next element
+					next($images);
+
+					/**
+					 * Start copy&paste from ImageProcessingTask::execute
+					 */
+
+					// Get a image lock
+					$lockKey = 'facerecognition/' . $image->getId();
+					$lockType = ILockingProvider::LOCK_EXCLUSIVE;
+
+					try {
+						$this->lockingProvider->acquireLock($lockKey, $lockType);
+					} catch (\OCP\Lock\LockedException $e) {
+						$this->logInfo('Faces found: 0. Image ' . $image->getId() . ' will be skipped because it is locked');
+						continue;
+					}
+
+					$dbImage = $this->imageMapper->find($image->getUser(), $image->getId());
+					if ($dbImage->getIsProcessed()) {
+						$this->logInfo('Faces found: 0. Image will be skipped since it was already processed.');
+						// Release lock of file.
+						$this->lockingProvider->releaseLock($lockKey, $lockType);
+						continue;
+					}
+
+					// Get an temp Image to process this image.
+					$tempImage = $this->getTempImage($image);
+
+					if (is_null($tempImage)) {
+						// If we cannot find a file probably it was deleted out of our control and we must clean our tables.
+						$this->settingsService->setNeedRemoveStaleImages(true, $image->user);
+						$this->logInfo('File with ID ' . $image->file . ' doesn\'t exist anymore, skipping it');
+						// Release lock of file.
+						$this->lockingProvider->releaseLock($lockKey, $lockType);
+						continue;
+					}
+
+					if ($tempImage->getSkipped() === true) {
+						$this->logInfo('Faces found: 0 (image will be skipped because it is too small)');
+						$this->imageMapper->imageProcessed($image, array(), 0);
+						// Release lock of file.
+						$this->lockingProvider->releaseLock($lockKey, $lockType);
+						continue;
+					}
+
+					// Get faces in the temporary image
+					$tempImagePath = $tempImage->getTempPath();
+					
+					/**
+					 * End copy&paste from ImageProcessingTask::execute
+					 */
+					
+
+					
+					$instance = -1;
+					// Select an actual instance to which the task will be assigned
+					// First, check if there are and idle instances for which there are no prepared tasks
+					if(count($idleInstances) > 0) {
+						foreach($idleInstances as $i) {
+							if(!array_key_exists($i, $preparedInstances)) {
+								$instance = $i;
+								break;
+							}
+						}
+					}
+					// If there are no idling instances without prepared tasksm, the we can just take the first free instance
+					if($instance == -1) {
+						$instance = array_key_first($freeInstances);	// take the first free instance
+					} 
+					$ich = array_shift($unusedCurlHandles);		// take the first unused handle
+					$ch = $chs[$ich];							// get the actual handle
+
+					// Prepare the cURL request.
+					if($this->modelConsecutivePorts) {
+						// External Model instances have different, consecutive ports --> modify URL
+						$this->prepDetectFacesRequest($ch, $tempImagePath, $basePort+$instance);
+					} else {
+						// External Model instances are behind a load balancer, we always call the same URL.
+						$this->prepDetectFacesRequest($ch, $tempImagePath);
+					}
+
+					
+					// put all the info into an array for later use
+					$task = [];
+					$task["image"] = $image;
+					$task["lockKey"] = $lockKey;
+					$task["lockType"] = $lockType;
+					$task["tempImage"] = $tempImage;
+					$task["instance"] = $instance;
+					$task["iCurlHandle"] = $ich;
+					$task["curlHandle"] = $ch;
+
+					if(array_key_exists($instance, $preparedInstances)) {
+						$this->logInfo("ERROR: Instance #$instance already has a prepared task which will be overwritten. This should not have happened :-(");
+						var_dump($this->preparedTasks[$instance]);
+					}
+					unset($freeInstances[$instance]);				// instance is no longer free
+					$preparedInstances[$instance] = $instance;		// add instance index to array to indicate that a task has been prepared for that instance
+					$this->preparedTasks[$instance] = $task;		// add task to array of prepared tasks
+
+					$this->logDebug("Image prepared for analysis by instance #$instance:  " . $task["tempImage"]->getImagePath());
+				}
+			}
+			// End of "Prepare task"
+			// ----------------------------------------------------------------------------------------------------
+
+
+
+			/**====================================================================================================
+			 * Fill queue
+			 */
+
+			// Check if there are idling instances
+			if(count($idleInstances) > 0) {
+				$instance = -1;
+				foreach($idleInstances as $i) {
+					if(array_key_exists($i, $preparedInstances)) {
+						$instance = $i;
+						break;
+					}
+				}
+				if($instance < 0) {
+					$this->logDebug("No task prepared for any of the idle instances [" . implode(", ", $idleInstances) . "] --> looks like we're almost done.");
+					// by the logic implemented in "prepare tasks" above, the next image analysis task should be assigned to an idling instance --> nothing to do here
+				} else {
+
+					$task = $this->preparedTasks[$instance];		// get task
+					$this->scheduledTasks[$instance] = $task;		// add to scheduled tasks
+					unset($this->preparedTasks[$instance]);			// remove from prepared tasks
+
+					unset($preparedInstances[$instance]);			// Remove instance from list of prepared instances, and
+					$freeInstances[$instance] = $instance;			// mark instance as free.
+					
+					unset($idleInstances[$instance]);				// Remove instance from list of idle instances, and
+					$activeInstances[$instance] = $instance;		// mark instance as active.
+					
+					$ch = $task["curlHandle"];
+					$this->scheduledTasks[$instance]["startMillis"] = round(microtime(true) * 1000);
+
+					$this->logDebug("Image scheduled for analysis by instance #$instance: " . $task["tempImage"]->getImagePath());
+
+					// ad cURL handle to multi handle --> request will be executed
+					curl_multi_add_handle($mh, $ch);
+				}
+
+			}
+			// End of "Fill queue"
+			// ----------------------------------------------------------------------------------------------------
+			
+
+
+
+			// Execute analysis requests
+			curl_multi_exec($mh, $active);
+
+			if ($active) {
+				// Wait a short time for more activity
+				curl_multi_select($mh);
+			}
+
+			// see https://stackoverflow.com/questions/75286863/process-curl-multi-exec-results-while-in-progress
+			// Consume any completed transfers
+			$curlMultiInfoRead = [];
+			while ($curlMultiInfoRead = curl_multi_info_read($mh, $queued_messages)) {
+
+				$ch = $curlMultiInfoRead['handle'];
+				// Check CurlHandle has not had an error
+
+				$this->logDebug("cURL result available: return code " . $curlMultiInfoRead["result"]);
+				
+				// Identify which of the tasks has been ompleted
+				unset($task);
+				for($instance = 0; $instance < $nInstances; $instance++) {
+					if($this->scheduledTasks[$instance]["curlHandle"] == $ch) {
+						$task = $this->scheduledTasks[$instance];
+						break;
+					}
+				}
+				
+				// Oops
+				if(!isset($task)) {
+					$this->logInfo("ERROR: cURL handle " . var_export($ch) . " does not correspond to any scheduled task. This should not have happened :-(");
+					curl_close($ch);	// close handle, we don't know this handle...
+					curl_multi_remove_handle($mh, $ch);
+					continue;
+				}
+
+				if($curlMultiInfoRead['result'] === CURLE_GOT_NOTHING) {
+					$this->logInfo("WARNING: The external model instance #" . $task["instance"] . " returned no result for image " . $task["tempImage"]->getImagePath() . ". Reduce the number of model instances, or, if the model instances are hosted on the same machine, increase the overall RAM of the host.");
+					curl_multi_remove_handle($mh, $ch);
+					curl_multi_add_handle($mh, $ch);
+					continue;
+
+				} elseif($curlMultiInfoRead['result'] !== CURLE_OK) {
+					$this->logInfo("WARNING: Couldn't connect to model instance #" . $task["instance"] . ". Retrying...");
+					curl_multi_remove_handle($mh, $ch);
+					curl_multi_add_handle($mh, $ch);
+					continue;
+				} elseif($curlMultiInfoRead['result'] !== CURLE_OK) {
+					throw new \RuntimeException(curl_error($ch));
+				}
+
+				$startMillis = $task["startMillis"];
+				$image = $task["image"];
+				$tempImage = $task["tempImage"];
+				$lockKey = $task["lockKey"];
+				$lockType = $task["lockType"];
+				$ich = $task["iCurlHandle"];
+
+				$this->logDebug("Analysis of " . $tempImage->getImagePath() . " completed.");
+				
+
+				$response = curl_multi_getcontent($ch);
+				if (is_bool($response) or is_null($response)) {
+					$this->logInfo('Response ' . var_export($response, true) . " for " . $tempImage->getImagePath());
+					$tempImage->clean();
+					curl_multi_remove_handle($mh, $ch);
+					continue;
+					
+				} elseif(empty($response)) {
+					$this->logInfo("Response is EMPTY for " . $tempImage->getImagePath() . " --> image is skipped and will be retried later.");
+					$this->logInfo("This could be a sign for insufficient memory on the machine running the external model. Provide at least 1G per instance.");
+					$tempImage->clean();
+					curl_multi_remove_handle($mh, $ch);
+					continue;
+				}
+
+				$info = curl_getinfo($ch);
+
+				// evaluate response
+				$rawFaces = $this->evalDetectFacesResponse($response);
+				$this->logInfo('Faces found: ' . count($rawFaces) . " by " . $info['url'] . " in " . $tempImage->getImagePath());
+
+				
+				$faces = array();
+				foreach ($rawFaces as $rawFace) {
+					// Normalize face and landmarks from model to original size
+					$normFace = $this->getNormalizedFace($rawFace, $tempImage->getRatio());
+					// Convert from dictionary of face to our Face Db Entity.
+					$face = Face::fromModel($image->getId(), $normFace);
+					// Save the normalized Face to insert on database later.
+					$faces[] = $face;
+				}
+
+				// Save new faces fo database
+				$endMillis = round(microtime(true) * 1000);
+				$duration = (int) (max($endMillis - $startMillis, 0) / $nInstances);
+				$this->imageMapper->imageProcessed($image, $faces, $duration);
+
+				// Clean temporary image.
+				$tempImage->clean();
+
+				// Release lock of file.
+				$this->lockingProvider->releaseLock($lockKey, $lockType);
+
+				// Remove cURL handle from multi-handle
+				curl_multi_remove_handle($mh, $ch);
+				array_push($unusedCurlHandles, $ich);
+
+				unset($activeInstances[$instance]);				// Remove instance from list of active instances, and
+				$idleInstances[$instance] = $instance;			// mark instance as idle.
+
+			}
+
+		} while(count($activeInstances) > 0 or count($preparedInstances) > 0);
+
+		// Close cURL handles
+		foreach($chs as $ch) {
+			curl_close($ch);
+		}
+
+		// Close cURL multi-handle
+		curl_multi_close($mh);
+
+		// If there are temporary files from external files, they must also be cleaned.
+		$this->fileService->clean();
+
+		$this->logInfo('NOTE: Face recognition task finished.');
+
+		return true;
+	}
+
+	/**
+	 * Given an image, build a temporary image to perform the analysis
+	 *
+	 * return TempImage|null
+	 */
+	private function getTempImage(Image $image): ?TempImage {
+		// todo: check if this hits I/O (database, disk...), consider having lazy caching to return user folder from user
+		$file = $this->fileService->getFileById($image->getFile(), $image->getUser());
+		if (empty($file)) {
+			return null;
+		}
+
+		if (!$this->fileService->isAllowedNode($file)) {
+			return null;
+		}
+
+		$imagePath = $this->fileService->getLocalFile($file);
+		if ($imagePath === null)
+			return null;
+
+		$this->logInfo('Processing image ' . $imagePath);
+
+		$tempImage = new TempImage($imagePath,
+		                           $this->model->getPreferredMimeType(),
+		                           $this->getMaxImageArea(),
+		                           $this->settingsService->getMinimumImageSize());
+
+		return $tempImage;
+	}
+
+	/**
+	 * Obtains max image area lazily (from cache, or calculates it and puts it to cache)
+	 *
+	 * @return int Max image area (in pixels^2)
+	 */
+	private function getMaxImageArea(): int {
+		// First check if is cached
+		//
+		if (!is_null($this->maxImageAreaCached)) {
+			return $this->maxImageAreaCached;
+		}
+
+		// Get this setting on main app_config.
+		// Note that this option has lower and upper limits and validations
+		$this->maxImageAreaCached = $this->settingsService->getAnalysisImageArea();
+
+		// Check if admin override it in config and it is valid value
+		//
+		$maxImageArea = $this->settingsService->getMaximumImageArea();
+		if ($maxImageArea > 0) {
+			$this->maxImageAreaCached = $maxImageArea;
+		}
+		// Also check if we are provided value from command line.
+		//
+		if ((array_key_exists('max_image_area', $this->context->propertyBag)) &&
+		    (!is_null($this->context->propertyBag['max_image_area']))) {
+			$this->maxImageAreaCached = $this->context->propertyBag['max_image_area'];
+		}
+
+		return $this->maxImageAreaCached;
+	}
+
+	/**
+	 * Helper method, to normalize face sizes back to original dimensions, based on ratio
+	 *
+	 */
+	private function getNormalizedFace(array $rawFace, float $ratio): array {
+		$face = [];
+		$face['left'] = intval(round($rawFace['left']*$ratio));
+		$face['right'] = intval(round($rawFace['right']*$ratio));
+		$face['top'] = intval(round($rawFace['top']*$ratio));
+		$face['bottom'] = intval(round($rawFace['bottom']*$ratio));
+		$face['detection_confidence'] = $rawFace['detection_confidence'];
+		$face['landmarks'] = $this->getNormalizedLandmarks($rawFace['landmarks'], $ratio);
+		$face['descriptor'] = $rawFace['descriptor'];
+		return $face;
+	}
+
+	/**
+	 * Helper method, to normalize landmarks sizes back to original dimensions, based on ratio
+	 *
+	 */
+	private function getNormalizedLandmarks(array $rawLandmarks, float $ratio): array {
+		$landmarks = [];
+		foreach ($rawLandmarks as $rawLandmark) {
+			$landmark = [];
+			$landmark['x'] = intval(round($rawLandmark['x']*$ratio));
+			$landmark['y'] = intval(round($rawLandmark['y']*$ratio));
+			$landmarks[] = $landmark;
+		}
+		return $landmarks;
+	}
+
+}

--- a/lib/BackgroundJob/Tasks/ImageProcessingWithMultipleExternalModelInstancesTask.php
+++ b/lib/BackgroundJob/Tasks/ImageProcessingWithMultipleExternalModelInstancesTask.php
@@ -598,7 +598,7 @@ class ImageProcessingWithMultipleExternalModelInstancesTask extends FaceRecognit
 
 			}
 
-		} while(count($activeInstances) > 0 or count($preparedInstances) > 0);
+		} while(current($images) or count($activeInstances) > 0 or count($preparedInstances) > 0);
 
 		// Close cURL handles
 		foreach($chs as $ch) {

--- a/lib/Command/SetupCommand.php
+++ b/lib/Command/SetupCommand.php
@@ -308,10 +308,11 @@ class SetupCommand extends Command {
 				$model->getDescription()
 			]);
 		}
+		unset($model);
 		$table->render();
 		$io->newLine(2);
 
-		$io->section('External model options' . ($model->getId() == ExternalModel::FACE_MODEL_ID ? '' : ' (no effect as the external model is not enabled)') . ':');
+		$io->section('External model options' . ($currentModel->getId() == ExternalModel::FACE_MODEL_ID ? '' : ' (no effect as the external model is not enabled)') . ':');
 		$this->logger->writeln('  URL: <info>' . $this->settingsService->getExternalModelUrl() . '</info>');
 		if($this->settingsService->getExternalModelApiKey() === SettingsService::SYSTEM_EXTERNAL_MODEL_DEFAULT_API_KEY) {
 			$this->logger->writeln('  API key: <comment>WARNING</comment>: the default API key "<info>' . SettingsService::SYSTEM_EXTERNAL_MODEL_DEFAULT_API_KEY . '"</info> is configured. This default value should not be used. Please set a proper API key in your external model. See https://github.com/matiasdelellis/facerecognition-external-model for more information.');
@@ -330,7 +331,7 @@ class SetupCommand extends Command {
 			$basePort = $matches[2];
 		} else {
 			if($this->settingsService->getExternalModelInstancesHaveConsecutivePorts()) {
-				$this->logger->writeln("    <error>" . ($model->getId() == ExternalModel::FACE_MODEL_ID ? 'CRITICAL' : 'ERROR') . ':</error> The external model URL must explicitly specify a port when "consecutive_ports" is "true".');
+				$io->caution("    " . ($currentModel->getId() == ExternalModel::FACE_MODEL_ID ? 'CRITICAL' : 'ERROR') . ': The external model URL must explicitly specify a port when "consecutive_ports" is "true".');
 			}
 		}		
 		if($basePort > 0 and $nInstances > 1 and $this->settingsService->getExternalModelInstancesHaveConsecutivePorts()) {

--- a/lib/Helper/TempImage.php
+++ b/lib/Helper/TempImage.php
@@ -76,6 +76,15 @@ class TempImage extends Image {
 	}
 
 	/**
+	 * Get the path of the image
+	 *
+	 * @return string
+	 */
+	public function getImagePath(): string {
+		return $this->imagePath;
+	}
+
+	/**
 	 * Get the path of temporary image
 	 *
 	 * @return string

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -141,12 +141,11 @@ class SettingsService {
 	/** System setting to configure external model */
 	const SYSTEM_EXTERNAL_MODEL_URL = 'facerecognition.external_model_url';
 	const SYSTEM_EXTERNAL_MODEL_API_KEY = 'facerecognition.external_model_api_key';
+	const SYSTEM_EXTERNAL_MODEL_DEFAULT_API_KEY = 'some-super-secret-api-key';
 	const SYSTEM_EXTERNAL_MODEL_NUMBER_OF_INSTANCES = 'facerecognition.external_model_number_of_instances';
 	const SYSTEM_EXTERNAL_MODEL_DEFAULT_NUMBER_OF_INSTANCES = '1';
 	const SYSTEM_EXTERNAL_MODEL_INSTANCES_HAVE_CONSECUTIVE_PORTS = 'facerecognition.external_model_instances_have_consecutive_ports';
 	const SYSTEM_EXTERNAL_MODEL_DEFAULT_INSTANCES_HAVE_CONSECUTIVE_PORTS = 'true';
-	const SYSTEM_EXTERNAL_MODEL_INSTANCE_DEFAULT_PORT = 'facerecognition.external_model_instance_default_port';
-	const SYSTEM_EXTERNAL_MODEL_DEFAULT_INSTANCE_DEFAULT_PORT = '8080';
 
 	/**
 	 * SettingsService
@@ -381,6 +380,13 @@ class SettingsService {
 	}
 
 	/**
+	 * Set external model url
+	 */
+	public function setExternalModelUrl(string $modelUrl): void {
+		$this->config->SetSystemValue(self::SYSTEM_EXTERNAL_MODEL_URL, $modelUrl);
+	}
+
+	/**
 	 * External model Api Key
 	 */
 	public function getExternalModelApiKey(): ?string {
@@ -388,14 +394,27 @@ class SettingsService {
 	}
 
 	/**
-	 * External model number of instances
+	 * Set external model Api Key
+	 */
+	public function setExternalModelApiKey(string $apiKey): void {
+		$this->config->setSystemValue(self::SYSTEM_EXTERNAL_MODEL_API_KEY, $apiKey);
+	}
+
+	/**
+	 * Get number of external model instances
 	 */
 	public function getExternalModelNumberOfInstances(): int {
 		return intval($this->config->getSystemValue(self::SYSTEM_EXTERNAL_MODEL_NUMBER_OF_INSTANCES, self::SYSTEM_EXTERNAL_MODEL_DEFAULT_NUMBER_OF_INSTANCES));;
 	}
+	/**
+	 * Set number of external model instances
+	 */
+	public function setExternalModelNumberOfInstances(int $nInstances): void {
+		$this->config->setSystemValue(self::SYSTEM_EXTERNAL_MODEL_NUMBER_OF_INSTANCES, strval($nInstances));;
+	}
 
 	/**
-	 * External model instances (if there are more than one...) have consecutive ports 
+	 * Get system setting regarding whether external model instances (if there are more than one...) have consecutive ports, e.g. first instance listens on port 8080, the second one listens on port 8081, the third one listens on port 8082, end so on...
 	 */
 	public function getExternalModelInstancesHaveConsecutivePorts(): bool {
 		$consecutivePorts = $this->config->getSystemValue(self::SYSTEM_EXTERNAL_MODEL_INSTANCES_HAVE_CONSECUTIVE_PORTS, self::SYSTEM_EXTERNAL_MODEL_DEFAULT_INSTANCES_HAVE_CONSECUTIVE_PORTS);
@@ -403,10 +422,10 @@ class SettingsService {
 	}
 
 	/**
-	 * External model number of instances
+	 * Set the system setting whether external model instances have consecutive ports.
 	 */
-	public function getExternalModelInstanceDefaultPort(): int {
-		return intval($this->config->getSystemValue(self::SYSTEM_EXTERNAL_MODEL_INSTANCE_DEFAULT_PORT, self::SYSTEM_EXTERNAL_MODEL_DEFAULT_INSTANCE_DEFAULT_PORT));;
+	public function setExternalModelInstancesHaveConsecutivePorts(bool $b): void {
+		$this->config->setSystemValue(self::SYSTEM_EXTERNAL_MODEL_INSTANCES_HAVE_CONSECUTIVE_PORTS, $b ? 'true' : 'false');
 	}
 
 }

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -141,6 +141,12 @@ class SettingsService {
 	/** System setting to configure external model */
 	const SYSTEM_EXTERNAL_MODEL_URL = 'facerecognition.external_model_url';
 	const SYSTEM_EXTERNAL_MODEL_API_KEY = 'facerecognition.external_model_api_key';
+	const SYSTEM_EXTERNAL_MODEL_NUMBER_OF_INSTANCES = 'facerecognition.external_model_number_of_instances';
+	const SYSTEM_EXTERNAL_MODEL_DEFAULT_NUMBER_OF_INSTANCES = '1';
+	const SYSTEM_EXTERNAL_MODEL_INSTANCES_HAVE_CONSECUTIVE_PORTS = 'facerecognition.external_model_instances_have_consecutive_ports';
+	const SYSTEM_EXTERNAL_MODEL_DEFAULT_INSTANCES_HAVE_CONSECUTIVE_PORTS = 'true';
+	const SYSTEM_EXTERNAL_MODEL_INSTANCE_DEFAULT_PORT = 'facerecognition.external_model_instance_default_port';
+	const SYSTEM_EXTERNAL_MODEL_DEFAULT_INSTANCE_DEFAULT_PORT = '8080';
 
 	/**
 	 * SettingsService
@@ -379,6 +385,28 @@ class SettingsService {
 	 */
 	public function getExternalModelApiKey(): ?string {
 		return $this->config->getSystemValue(self::SYSTEM_EXTERNAL_MODEL_API_KEY, null);
+	}
+
+	/**
+	 * External model number of instances
+	 */
+	public function getExternalModelNumberOfInstances(): int {
+		return intval($this->config->getSystemValue(self::SYSTEM_EXTERNAL_MODEL_NUMBER_OF_INSTANCES, self::SYSTEM_EXTERNAL_MODEL_DEFAULT_NUMBER_OF_INSTANCES));;
+	}
+
+	/**
+	 * External model instances (if there are more than one...) have consecutive ports 
+	 */
+	public function getExternalModelInstancesHaveConsecutivePorts(): bool {
+		$consecutivePorts = $this->config->getSystemValue(self::SYSTEM_EXTERNAL_MODEL_INSTANCES_HAVE_CONSECUTIVE_PORTS, self::SYSTEM_EXTERNAL_MODEL_DEFAULT_INSTANCES_HAVE_CONSECUTIVE_PORTS);
+		return ($consecutivePorts === 'true');
+	}
+
+	/**
+	 * External model number of instances
+	 */
+	public function getExternalModelInstanceDefaultPort(): int {
+		return intval($this->config->getSystemValue(self::SYSTEM_EXTERNAL_MODEL_INSTANCE_DEFAULT_PORT, self::SYSTEM_EXTERNAL_MODEL_DEFAULT_INSTANCE_DEFAULT_PORT));;
 	}
 
 }


### PR DESCRIPTION
**Summary:** with this change multiple instances of the external model can be used to analyze multiple images in parallel.

**Motivation:**
Since the [recent change that analysis now uses more than one core](https://github.com/matiasdelellis/facerecognition/discussions/716#discussioncomment-8109403) the external model is kind of pointless (because it's only analyzing one image in one thread / using one core).
That is especially sad if you have (for whatever reasons) a machine with a lot of cores and RAM that could easily analyze more than one image at one.

**Enter "Multiple external model instances":**
With this change you can use multiple external model instances in parallel. For that, the new `ImageProcessingWithMultipleExternalModelInstancesTask` has been added which brings together the code from the original `ImageProcessingTask` and the `ExternalModel` and whips that up with `curl_multi_exec` to asynchronically send image analysis requests to the external model instances.

**Configuration:**
All relevant settings on the facerecognition app side can be set using the `occ face:setup` command. Usage is displayed with `occ face:setup -h`.

The by far easiest solution is to use docker compose for the external model. There are only two changes to the `docker-compose.yml` required:
1. you need to map a port range to the containers internal port rather than a single port mapping. The number of ports must be at least the number of instances:
The following configuration line will use port 8083 through 8090.
```
     ports:
       - "8083-8090:5000"
``` 
2. you specify that replicas shall be deployed:
The following configuration line will result in a total of 8 instances of the external model.
```
     deploy:
       mode: replicated
       replicas: 8
```
Each replica will listen on subsequent ports, starting with the first port in above configured port range.

**Changes to facerecognition:**
I tried to make as little chanegs to the original code as possible.
Three things were unavoidable:
1. Add the related system settings to `SettingsService`.
2. Change the `FaceRecognitionBackgroundTask` to add a cleanup method in order to be able to react to timeout.
3. Introduce a new class for the Task and schedule it in the `BackgroundService`.

Besides that, I modified the `SetupCommand` to have access to more settings and to show the current settings a bit nicer :-)
Also I have added Nextcloud's internal logger to the `FaceRecognitionContext` so that we can send messages to the Nextcloud log file.

**Final words:**
I have tried this on my server and on a machine with 16GB memory I can run 8 instances in parallel (with a temp image size of 1600x1200).