### PR TITLE
Update autocomplete to enable cache and return most recent requests

### DIFF
--- a/src/dialogs.js
+++ b/src/dialogs.js
@@ -22,6 +22,7 @@
 /**
  * this class to ease the usage of jquery dialogs
  */
+
 const FrDialogs = {
 
 	hide: function (faces, callback) {
@@ -157,15 +158,22 @@ const FrDialogs = {
 				}
 			});
 
+			var autocomplete_cnt = 0;
+			var autocomplete_lst = 0;
 			new AutoComplete({
 				input: document.getElementById(dialogName + "-input"),
 				lookup (query) {
+					let autocomplete_cnt_itr = ++autocomplete_cnt;
 					return new Promise(resolve => {
 						$.get(OC.generateUrl('/apps/facerecognition/autocomplete/' + query)).done(function (names) {
-							resolve(names);
+							if (autocomplete_cnt_itr > autocomplete_lst) {
+								autocomplete_lst = autocomplete_cnt_itr;
+								resolve(names);
+							}
 						});
 					});
 				},
+				cache: true,
 				silent: true,
 				highlight: false
 			});
@@ -245,15 +253,22 @@ const FrDialogs = {
 				}
 			});
 
+			var autocomplete_cnt = 0;
+			var autocomplete_lst = 0;
 			new AutoComplete({
 				input: document.getElementById(dialogName + "-input"),
 				lookup (query) {
+					let autocomplete_cnt_itr = ++autocomplete_cnt;
 					return new Promise(resolve => {
 						$.get(OC.generateUrl('/apps/facerecognition/autocomplete/' + query)).done(function (names) {
-							resolve(names);
+							if (autocomplete_cnt_itr > autocomplete_lst) {
+								autocomplete_lst = autocomplete_cnt_itr;
+								resolve(names);
+							}
 						});
 					});
 				},
+				cache: true,
 				silent: true,
 				highlight: false
 			});
@@ -347,15 +362,22 @@ const FrDialogs = {
 				}
 			});
 
+			var autocomplete_cnt = 0;
+			var autocomplete_lst = 0;
 			new AutoComplete({
 				input: document.getElementById(dialogName + "-input"),
 				lookup (query) {
+					let autocomplete_cnt_itr = ++autocomplete_cnt;
 					return new Promise(resolve => {
 						$.get(OC.generateUrl('/apps/facerecognition/autocomplete/' + query)).done(function (names) {
-							resolve(names);
+							if (autocomplete_cnt_itr > autocomplete_lst) {
+								autocomplete_lst = autocomplete_cnt_itr;
+								resolve(names);
+							}
 						});
 					});
 				},
+				cache: true,
 				silent: true,
 				highlight: false
 			});
@@ -440,15 +462,22 @@ const FrDialogs = {
 				}
 			});
 
+			var autocomplete_cnt = 0;
+			var autocomplete_lst = 0;
 			new AutoComplete({
 				input: document.getElementById(dialogName + "-input"),
-				lookup (query) {
+				lookup (query) {	
+					let autocomplete_cnt_itr = ++autocomplete_cnt;
 					return new Promise(resolve => {
 						$.get(OC.generateUrl('/apps/facerecognition/autocomplete/' + query)).done(function (names) {
-							resolve(names);
+							if (autocomplete_cnt_itr > autocomplete_lst) {
+								autocomplete_lst = autocomplete_cnt_itr;
+								resolve(names);
+							}
 						});
 					});
 				},
+				cache: true,
 				silent: true,
 				highlight: false
 			});


### PR DESCRIPTION
This adds two things to the AutoComplete instantiations:

* cache - this is a minimal benefit, but still means less db queries if someone uses backspace and re-types something
* adds a simple query counter so that older query results from slower database transactions don't overwrite newer ones

Fixes #766 

Tested this in my local Nextcloud (29.0.4) with dev tools in Firefox 128.0.